### PR TITLE
Add C language support (llvm-mos) with QE Japanese text editor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,19 +33,26 @@ jobs:
       run: |
         # Install 64tass from Ubuntu repositories
         sudo apt-get install -y 64tass
-        
+
         # Download and install prog8 compiler
         wget https://github.com/irmen/prog8/releases/download/v11.4.1/prog8c-11.4.1-all.jar
         sudo mkdir -p /opt/prog8
         sudo mv prog8c-11.4.1-all.jar /opt/prog8/
-        
+
         # Create wrapper script
         sudo tee /usr/local/bin/prog8c << 'EOF'
         #!/bin/bash
         java -jar /opt/prog8/prog8c-11.4.1-all.jar "$@"
         EOF
         sudo chmod +x /usr/local/bin/prog8c
-        
+
+    - name: Install llvm-mos toolchain
+      run: |
+        # Download and install llvm-mos
+        wget https://github.com/llvm-mos/llvm-mos-sdk/releases/latest/download/llvm-mos-linux.tar.xz
+        sudo mkdir -p /opt/llvm-mos
+        sudo tar -xf llvm-mos-linux.tar.xz -C /opt/llvm-mos --strip-components=1
+        echo "/opt/llvm-mos/bin" >> $GITHUB_PATH
     - name: Test font conversion
       run: make fonts
       
@@ -74,4 +81,5 @@ jobs:
         echo "✅ Build completed successfully"
         echo "📦 CRT size: $(stat -c%s crt/c64jpkanji.crt) bytes"
         echo "💾 D64 size: $(stat -c%s prog8/build/c64jp_programs.d64) bytes"
-        echo "🎯 Programs built: hello, hello_bitmap, hello_resource, ime_test, modem_test"
+        echo "🎯 Prog8 programs: hello, hello_bitmap, hello_resource, ime_test, modem_test"
+        echo "🔧 C programs: qe ($(stat -c%s c/build/qe.prg) bytes)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,19 +32,27 @@ jobs:
       run: |
         # Install 64tass from Ubuntu repositories
         sudo apt-get install -y 64tass
-        
+
         # Download and install prog8 compiler
         wget https://github.com/irmen/prog8/releases/download/v11.4.1/prog8c-11.4.1-all.jar
         sudo mkdir -p /opt/prog8
         sudo mv prog8c-11.4.1-all.jar /opt/prog8/
-        
+
         # Create wrapper script
         sudo tee /usr/local/bin/prog8c << 'EOF'
         #!/bin/bash
         java -jar /opt/prog8/prog8c-11.4.1-all.jar "$@"
         EOF
         sudo chmod +x /usr/local/bin/prog8c
-        
+
+    - name: Install llvm-mos toolchain
+      run: |
+        # Download and install llvm-mos
+        wget https://github.com/llvm-mos/llvm-mos-sdk/releases/latest/download/llvm-mos-linux.tar.xz
+        sudo mkdir -p /opt/llvm-mos
+        sudo tar -xf llvm-mos-linux.tar.xz -C /opt/llvm-mos --strip-components=1
+        echo "/opt/llvm-mos/bin" >> $GITHUB_PATH
+
     - name: Build fonts (with automatic download)
       run: make fonts
       
@@ -66,7 +74,11 @@ jobs:
         cp README.md release/
         cp README-en.md release/
         cp LICENSE release/
-        
+
+        # Add C programs documentation
+        mkdir -p release/c/qe
+        cp c/src/qe/README.md release/c/qe/
+
         # Create release zip
         cd release
         zip -r ../c64jp-${{ steps.get_version.outputs.VERSION }}.zip .
@@ -101,12 +113,18 @@ jobs:
           3. `LOAD"$",8` でディレクトリ表示し、`LOAD"プログラム名",8,1` で実行
           
           ## 含まれるプログラム
-          
+
+          ### Prog8版
           - **HELLO** - 基本的な日本語表示デモ
           - **HELLO BITMAP** - ビットマップモード日本語表示
           - **HELLO RESOURCE** - 文字列リソース使用例
           - **IME TEST** - かな漢字変換IMEテスト
           - **MODEM TEST** - SwiftLink RS-232通信テスト
+
+          ### C言語版（llvm-mos）
+          - **QE** - Vi-like日本語テキストエディタ
+            - Shift-JIS対応、IME統合、ファイルI/O機能付き
+            - 詳細は `c/src/qe/README.md` を参照
           
           ---
           

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,13 @@
 # prog8コンパイラ生成ファイル
 prog8/build/
 
+# C/llvm-mosコンパイラ生成ファイル
+c/build/
+*.o
+*.obj
+*.elf
+*.hex
+
 # Python生成ファイル
 __pycache__/
 *.py[cod]

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ DICCONV_DIR := $(PROJECT_ROOT)/dicconv
 FONTCONV_DIR := $(PROJECT_ROOT)/fontconv
 CREATECRT_DIR := $(PROJECT_ROOT)/createcrt
 STRINGRES_DIR := $(PROJECT_ROOT)/stringresources
+C_DIR := $(PROJECT_ROOT)/c
+C_BUILD_DIR := $(C_DIR)/build
 
 # Default values
 TARGET ?= hello
@@ -72,6 +74,20 @@ help:
 	@echo "  make release-files     - Create both CRT and D64 files"
 	@echo "  make clean             - Remove build artifacts"
 	@echo "  make clean-all         - Remove all generated files including fonts"
+	@echo ""
+	@echo "C version targets:"
+	@echo "  make c-build           - Build C version with llvm-mos"
+	@echo "  make c-hello           - Build and run C hello program"
+	@echo "  make c-test            - Build and run C test program"
+	@echo "  make c-ime-test        - Build and run C IME test program"
+	@echo "  make c-clean           - Remove C build artifacts"
+	@echo ""
+	@echo "QE Text Editor targets:"
+	@echo "  make qe-build          - Build QE text editor"
+	@echo "  make qe-run            - Build and run QE text editor"
+	@echo "  make qe-test           - Build and run QE test program"
+	@echo "  make qe-clean          - Remove QE build artifacts"
+	@echo ""
 	@echo "  make help              - Show this help"
 	@echo ""
 	@echo "Examples:"
@@ -96,6 +112,9 @@ help:
 $(BUILD_DIR):
 	@mkdir -p $(BUILD_DIR)
 
+$(C_BUILD_DIR):
+	@mkdir -p $(C_BUILD_DIR)
+
 # Build program
 $(PRG_FILE): $(P8_FILE) | $(BUILD_DIR)
 	@echo "=== Prog8 Kanji Display Build ==="
@@ -104,7 +123,7 @@ $(PRG_FILE): $(P8_FILE) | $(BUILD_DIR)
 		exit 1; \
 	fi
 	@echo "Compiling: $(TARGET).p8"
-	@prog8c -target c64 -out "$(BUILD_DIR)" "$(P8_FILE)"
+	@prog8c -asmlist -target c64 -out "$(BUILD_DIR)" "$(P8_FILE)"
 	@echo "✓ $(TARGET).p8 compilation completed"
 
 # Font files creation
@@ -179,6 +198,8 @@ list:
 	@echo "=== Built Files ==="
 	@ls -la "$(BUILD_DIR)"/*.prg 2>/dev/null || echo "No PRG files found"
 
+
+
 # Execution targets
 .PHONY: run
 run: $(PRG_FILE) $(BASIC_CRT)
@@ -249,7 +270,7 @@ clean:
 	@echo "Cleanup completed"
 
 .PHONY: clean-all
-clean-all: clean
+clean-all: clean c-clean qe-clean
 	@echo "Removing all generated files..."
 	@rm -rf $(BUILD_DIR)
 	@cd $(FONTCONV_DIR) && $(MAKE) clean
@@ -276,12 +297,95 @@ debug:
 	@echo "EMU_MODEM_OPTS: $(EMU_MODEM_OPTS)"
 	@echo "EMU_EXTRA_OPTS: $(EMU_EXTRA_OPTS)"
 
+# C version targets
+.PHONY: c-build
+c-build: $(C_BUILD_DIR) $(BASIC_CRT)
+	@echo "=== Building C version with llvm-mos ==="
+	@if ! which mos-c64-clang >/dev/null 2>&1; then \
+		echo "Error: llvm-mos not found. Please install llvm-mos SDK."; \
+		echo "Visit: https://github.com/llvm-mos/llvm-mos-sdk"; \
+		exit 1; \
+	fi
+	@cd $(C_BUILD_DIR) && cmake ../
+	@cd $(C_BUILD_DIR) && make
+	@echo "C version build completed"
+
+.PHONY: c-hello
+c-hello: c-build
+	@echo "=== Running hello_c.prg ==="
+	@if which $(EMU_COMMAND) >/dev/null 2>&1; then \
+		"$(EMU_COMMAND)" $(EMU_CARTRIDGE_OPT) "$(BASIC_CRT)" $(EMU_AUTOSTART_OPT) "$(C_BUILD_DIR)/hello_c.prg" $(EMU_EXTRA_OPTS); \
+	else \
+		echo "Error: Emulator command not found: $(EMU_COMMAND)"; \
+		exit 1; \
+	fi
+
+.PHONY: c-test
+c-test: c-build
+	@echo "=== Running test_jtxt.prg ==="
+	@if which $(EMU_COMMAND) >/dev/null 2>&1; then \
+		"$(EMU_COMMAND)" $(EMU_CARTRIDGE_OPT) "$(BASIC_CRT)" $(EMU_AUTOSTART_OPT) "$(C_BUILD_DIR)/test_jtxt.prg" $(EMU_EXTRA_OPTS); \
+	else \
+		echo "Error: Emulator command not found: $(EMU_COMMAND)"; \
+		exit 1; \
+	fi
+
+.PHONY: c-ime-test
+c-ime-test: c-build
+	@echo "=== Running ime_test_c.prg ==="
+	@if which $(EMU_COMMAND) >/dev/null 2>&1; then \
+		"$(EMU_COMMAND)" $(EMU_CARTRIDGE_OPT) "$(BASIC_CRT)" $(EMU_AUTOSTART_OPT) "$(C_BUILD_DIR)/ime_test_c.prg" $(EMU_EXTRA_OPTS); \
+	else \
+		echo "Error: Emulator command not found: $(EMU_COMMAND)"; \
+		exit 1; \
+	fi
+
+.PHONY: c-clean
+c-clean:
+	@echo "Removing C build artifacts..."
+	@rm -rf $(C_BUILD_DIR)
+	@echo "C cleanup completed"
+
+# QE Text Editor targets
+.PHONY: qe-build
+qe-build: $(C_BUILD_DIR) $(BASIC_CRT)
+	@echo "=== Building QE Text Editor ==="
+	@cd $(C_DIR)/src/qe && $(MAKE) all
+	@echo "QE text editor build completed"
+
+.PHONY: qe-run
+qe-run: qe-build
+	@echo "=== Running QE Text Editor ==="
+	@if which $(EMU_COMMAND) >/dev/null 2>&1; then \
+		"$(EMU_COMMAND)" $(EMU_CARTRIDGE_OPT) "$(BASIC_CRT)" $(EMU_AUTOSTART_OPT) "$(C_BUILD_DIR)/qe.prg" $(EMU_EXTRA_OPTS); \
+	else \
+		echo "Error: Emulator command not found: $(EMU_COMMAND)"; \
+		exit 1; \
+	fi
+
+.PHONY: qe-test
+qe-test: $(C_BUILD_DIR) $(BASIC_CRT)
+	@echo "=== Building and running QE test ==="
+	@cd $(C_DIR)/src/qe && $(MAKE) test
+	@if which $(EMU_COMMAND) >/dev/null 2>&1; then \
+		"$(EMU_COMMAND)" $(EMU_CARTRIDGE_OPT) "$(BASIC_CRT)" $(EMU_AUTOSTART_OPT) "$(C_BUILD_DIR)/qe_fio_test.prg" $(EMU_EXTRA_OPTS); \
+	else \
+		echo "Error: Emulator command not found: $(EMU_COMMAND)"; \
+		exit 1; \
+	fi
+
+.PHONY: qe-clean
+qe-clean:
+	@echo "Cleaning QE build artifacts..."
+	@cd $(C_DIR)/src/qe && $(MAKE) clean
+	@echo "QE cleanup completed"
+
 # Commonly used combination aliases
 .PHONY: ime
 ime:
 	@$(MAKE) TARGET=ime_test run
 
-.PHONY: ime-strings  
+.PHONY: ime-strings
 ime-strings:
 	@$(MAKE) TARGET=ime_test run-strings
 
@@ -343,4 +447,3 @@ release-files: d64
 	@echo "CRT File: $(BASIC_CRT)"
 	@echo "D64 File: $(D64_IMAGE)"
 	@ls -la "$(BASIC_CRT)" "$(D64_IMAGE)"
-

--- a/Makefile
+++ b/Makefile
@@ -400,6 +400,7 @@ modem:
 # D64 disk image creation
 # Release targets for D64 creation
 RELEASE_TARGETS := hello hello_bitmap hello_resource ime_test modem_test
+C_RELEASE_TARGETS := qe
 D64_IMAGE := $(BUILD_DIR)/c64jp_programs.d64
 
 .PHONY: build-all
@@ -408,6 +409,11 @@ build-all:
 	@for target in $(RELEASE_TARGETS); do \
 		echo "Building $$target.p8..."; \
 		$(MAKE) TARGET=$$target $(BUILD_DIR)/$$target.prg || exit 1; \
+	done
+	@echo "Building C language programs..."
+	@for target in $(C_RELEASE_TARGETS); do \
+		echo "Building C/$$target..."; \
+		$(MAKE) -C $(C_DIR)/src/$$target || exit 1; \
 	done
 	@echo "All targets built successfully"
 
@@ -434,6 +440,15 @@ d64: build-all $(BASIC_CRT)
 			c1541 "$(D64_IMAGE)" -write "$(BUILD_DIR)/$$target.prg" "$$d64name"; \
 		else \
 			echo "  Warning: $$target.prg not found"; \
+		fi; \
+	done
+	@echo "Adding C language programs..."
+	@for target in $(C_RELEASE_TARGETS); do \
+		if [ -f "$(C_BUILD_DIR)/$$target.prg" ]; then \
+			echo "  Adding C/$$target.prg as \"$$target\""; \
+			c1541 "$(D64_IMAGE)" -write "$(C_BUILD_DIR)/$$target.prg" "$$target"; \
+		else \
+			echo "  Warning: C/$$target.prg not found"; \
 		fi; \
 	done
 	@echo "D64 disk image created: $(D64_IMAGE)"

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.18)
+set(LLVM_MOS_PLATFORM c64)
+find_package(llvm-mos-sdk REQUIRED)
+project(c64jp_c VERSION 1.0.0)
+
+# Build configuration
+add_compile_options(-Oz -Wall -flto)
+
+# jtxt library
+add_library(jtxt STATIC
+    src/jtxt.c
+    src/jtxt_text.c
+    src/jtxt_bitmap.c
+    src/jtxt_charset.c
+    src/jtxt_resource.c
+)
+
+target_include_directories(jtxt PUBLIC include)
+
+# IME library translated from Prog8 ime.p8
+add_library(ime STATIC
+    src/ime.c
+)
+
+target_link_libraries(ime PUBLIC jtxt)
+target_include_directories(ime PUBLIC include)
+
+# Test programs
+add_executable(hello_c src/hello.c)
+target_link_libraries(hello_c jtxt ime)
+
+add_executable(test_jtxt test/test_jtxt.c)
+target_link_libraries(test_jtxt jtxt)
+
+add_executable(ime_test_c src/ime_test.c)
+target_link_libraries(ime_test_c jtxt ime)
+
+# Generate PRG files
+add_custom_command(
+    TARGET hello_c POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:hello_c> ${CMAKE_BINARY_DIR}/hello_c.prg
+)
+
+add_custom_command(
+    TARGET test_jtxt POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:test_jtxt> ${CMAKE_BINARY_DIR}/test_jtxt.prg
+)
+
+add_custom_command(
+    TARGET ime_test_c POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:ime_test_c> ${CMAKE_BINARY_DIR}/ime_test_c.prg
+)

--- a/c/include/ime.h
+++ b/c/include/ime.h
@@ -1,0 +1,36 @@
+#ifndef IME_H
+#define IME_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define IME_DICTIONARY_START_BANK 10
+#define IME_DICTIONARY_END_BANK   27
+
+#define IME_EVENT_NONE            0
+#define IME_EVENT_CONFIRMED       1
+#define IME_EVENT_CANCELLED       2
+#define IME_EVENT_MODE_CHANGED    3
+#define IME_EVENT_DEACTIVATED     4
+#define IME_EVENT_KEY_PASSTHROUGH 5
+
+#define IME_MODE_HIRAGANA   0
+#define IME_MODE_KATAKANA   1
+#define IME_MODE_FULLWIDTH  2
+
+void ime_init(void);
+void ime_toggle_mode(void);
+bool ime_is_active(void);
+void ime_set_hiragana_mode(void);
+void ime_set_katakana_mode(void);
+void ime_set_alphanumeric_mode(void);
+uint8_t ime_get_input_mode(void);
+void ime_activate(void);
+void ime_deactivate(void);
+uint8_t ime_process(void);
+const uint8_t* ime_get_result_text(void);
+uint8_t ime_get_result_length(void);
+void ime_clear_output(void);
+uint8_t ime_get_passthrough_key(void);
+
+#endif /* IME_H */

--- a/c/include/jtxt.h
+++ b/c/include/jtxt.h
@@ -1,0 +1,116 @@
+#ifndef JTXT_H
+#define JTXT_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+// MagicDesk constants
+#define JTXT_ROM_BASE         0x8000U
+#define JTXT_BANK_REG         0xDE00U
+
+// Character constants
+#define JTXT_CHARSET_ROM      0xD000U
+#define JTXT_CHARSET_RAM      0x3000U
+#define JTXT_SCREEN_RAM       0x0400U
+#define JTXT_BITMAP_SCREEN_RAM 0x5C00U
+#define JTXT_COLOR_RAM        0xD800U
+#define JTXT_CHAR_WIDTH       40
+#define JTXT_CHAR_HEIGHT      25
+
+// Bitmap mode constants
+#define JTXT_BITMAP_BASE      0x6000U
+#define JTXT_TEXT_MODE        0
+#define JTXT_BITMAP_MODE      1
+
+// Font offsets
+#define JTXT_JISX0201_SIZE    2048U
+#define JTXT_JISX0208_OFFSET  JTXT_JISX0201_SIZE
+
+// String resource constants
+#define JTXT_STRING_RESOURCE_BANK 36
+#define JTXT_STRING_RESOURCE_BASE JTXT_ROM_BASE
+#define JTXT_STRING_BUFFER    0x0340U
+#define JTXT_STRING_BUFFER_SIZE 191
+
+// Library state
+typedef struct {
+    uint8_t chr_start;
+    uint8_t chr_count;
+    uint8_t current_index;
+    uint16_t screen_pos;
+    uint16_t color_pos;
+    uint8_t current_color;
+
+    // Shift-JIS state
+    uint8_t sjis_first_byte;
+
+    // Display mode
+    uint8_t display_mode;
+
+    // Bitmap mode variables
+    uint8_t cursor_x;
+    uint8_t cursor_y;
+    uint8_t bitmap_color;
+
+    // Bitmap window control
+    uint8_t bitmap_top_row;
+    uint8_t bitmap_bottom_row;
+    bool bitmap_window_enabled;
+} jtxt_state_t;
+
+// Main API functions
+void jtxt_init(uint8_t mode);
+void jtxt_cleanup(void);
+void jtxt_set_mode(uint8_t mode);
+void jtxt_set_range(uint8_t start_char, uint8_t char_count);
+
+// Text mode functions
+void jtxt_cls(void);
+void jtxt_locate(uint8_t x, uint8_t y);
+void jtxt_putc(uint8_t char_code);
+void jtxt_puts(const char* str);
+void jtxt_newline(void);
+void jtxt_set_color(uint8_t color);
+void jtxt_set_bgcolor(uint8_t bgcolor, uint8_t bordercolor);
+
+// Bitmap mode functions
+void jtxt_bcls(void);
+void jtxt_blocate(uint8_t x, uint8_t y);
+void jtxt_bputc(uint8_t char_code);
+void jtxt_bputs(const char* str);
+void jtxt_bnewline(void);
+void jtxt_bbackspace(void);
+void jtxt_bcolor(uint8_t fg, uint8_t bg);
+void jtxt_bwindow(uint8_t top_row, uint8_t bottom_row);
+void jtxt_bwindow_enable(void);
+void jtxt_bwindow_disable(void);
+void jtxt_bscroll_up(void);
+
+// String resource functions
+bool jtxt_load_string_resource(uint8_t resource_number);
+void jtxt_putr(uint8_t resource_number);
+void jtxt_bputr(uint8_t resource_number);
+
+// Utility functions
+bool jtxt_is_firstsjis(uint8_t char_code);
+void jtxt_bput_hex2(uint8_t value);
+void jtxt_bput_dec2(uint8_t value);
+void jtxt_bput_dec3(uint8_t value);
+
+// ROM access management functions
+void jtxt_rom_access_begin(void);
+void jtxt_rom_access_end(void);
+
+// Internal functions (exposed for modularity)
+void jtxt_copy_charset_to_ram(void);
+void jtxt_define_char(uint8_t char_code, uint16_t code);
+void jtxt_define_font(uint16_t dest_addr, uint16_t code);
+void jtxt_define_jisx0201(uint8_t jisx0201_code);
+void jtxt_define_kanji(uint16_t sjis_code);
+uint16_t jtxt_sjis_to_offset(uint16_t sjis_code);
+void jtxt_draw_font_to_bitmap(uint16_t char_code);
+
+// Global state access
+extern jtxt_state_t jtxt_state;
+
+#endif // JTXT_H

--- a/c/src/hello.c
+++ b/c/src/hello.c
@@ -1,0 +1,53 @@
+#include <c64.h>
+#include "jtxt.h"
+
+#define PEEK(addr) (*(volatile unsigned char*)(addr))
+
+int main(void) {
+    // Initialize jtxt library in text mode
+    jtxt_init(JTXT_TEXT_MODE);
+
+    // Clear screen
+    jtxt_cls();
+
+    // Set colors
+    jtxt_set_bgcolor(0, 0);  // Black background and border
+    jtxt_set_color(1);       // White text
+
+    // Display messages
+    jtxt_locate(10, 5);
+    jtxt_puts("Hello from C!");
+
+    jtxt_locate(5, 8);
+    // Test with Japanese text (Shift-JIS encoded)
+    const char japanese_text[] = {
+        0x82, 0xB1, 0x82, 0xF1, 0x82, 0xC9, 0x82, 0xBF, 0x82, 0xCD, // こんにちは
+        0x21, 0x00  // !
+    };
+    jtxt_puts(japanese_text);
+
+    jtxt_locate(5, 10);
+    jtxt_puts("C64 Japanese Text Library");
+
+    jtxt_locate(5, 12);
+    // Test half-width katakana
+    const char katakana_text[] = {
+        0xC6, 0xCE, 0xDD, 0xBA, 0xDE, // ニホンゴ
+        0x00
+    };
+    jtxt_puts(katakana_text);
+
+    // Wait for key press
+    jtxt_locate(5, 20);
+    jtxt_puts("Press any key...");
+
+    // Simple wait loop
+    while (PEEK(0xC6) == 0) {
+        // Wait for key press
+    }
+
+    // Cleanup
+    jtxt_cleanup();
+
+    return 0;
+}

--- a/c/src/ime.c
+++ b/c/src/ime.c
@@ -1,0 +1,2144 @@
+#include "ime.h"
+#include "jtxt.h"
+
+#include <c64.h>
+#include <cbm.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#define ROM_BASE 0x8000U
+#define BANK_REG 0xDE00U
+
+#define CIA1_DATA_A 0xDC00U
+#define CIA1_DATA_B 0xDC01U
+
+#define COLOR_DEFAULT_FG 1
+#define COLOR_DEFAULT_BG 0
+#define COLOR_STATUS_FG  0
+#define COLOR_STATUS_BG  1
+
+#define KEY_SPACE  32
+#define KEY_RETURN 13
+#define KEY_ESC    27
+
+#define COMMODORE_ROW 0x7FU
+#define COMMODORE_BIT 0x20U
+#define SPACE_ROW     0x7FU
+#define SPACE_BIT     0x10U
+
+#define FKEY_ROW      0xFEU
+#define F1_BIT        0x10U
+#define F3_BIT        0x20U
+#define F5_BIT        0x40U
+
+#define IME_STATUS_WIDTH 4
+
+#define ROMAJI_BUFFER_SIZE    8
+#define HIRAGANA_BUFFER_SIZE 64
+#define CONVERSION_KEY_SIZE   64
+#define CANDIDATE_BUFFER_SIZE 256
+#define MAX_CANDIDATES        16
+
+#define HIRAGANA_BUFFER_LIMIT (HIRAGANA_BUFFER_SIZE - 2)
+
+#define PEEK(addr) (*(volatile uint8_t*)(addr))
+#define POKE(addr, val) (PEEK(addr) = (uint8_t)(val))
+
+static uint16_t mkword(uint8_t hi, uint8_t lo) {
+    return ((uint16_t)hi << 8) | lo;
+}
+
+static uint8_t msb16(uint16_t value) {
+    return (uint8_t)(value >> 8);
+}
+
+static uint8_t lsb16(uint16_t value) {
+    return (uint8_t)(value & 0xFF);
+}
+
+enum {
+    ROMAJI_EMPTY = 0,
+    ROMAJI_CONSONANT,
+    ROMAJI_N,
+    ROMAJI_SMALL_TSU,
+    ROMAJI_WAITING_2ND,
+    ROMAJI_X_PREFIX,
+    ROMAJI_Y_WAITING,
+    ROMAJI_SKIP_NEXT
+};
+
+enum {
+    IME_STATE_INPUT = 0,
+    IME_STATE_CONVERTING = 1
+};
+
+static const uint16_t basic_hiragana[] = {
+    0x82A0, 0x82A2, 0x82A4, 0x82A6, 0x82A8,
+    0x82A9, 0x82AB, 0x82AD, 0x82AF, 0x82B1,
+    0x82B3, 0x82B5, 0x82B7, 0x82B9, 0x82BB,
+    0x82BD, 0x82BF, 0x82C2, 0x82C4, 0x82C6,
+    0x82C8, 0x82C9, 0x82CA, 0x82CB, 0x82CC,
+    0x82CD, 0x82D0, 0x82D3, 0x82D6, 0x82D9,
+    0x82DC, 0x82DD, 0x82DE, 0x82DF, 0x82E0,
+    0x82E2, 0x82E4, 0x82E6,
+    0x82E7, 0x82E8, 0x82E9, 0x82EA, 0x82EB,
+    0x82ED, 0x82F0, 0x82F1
+};
+
+static const uint16_t dakuten_hiragana[] = {
+    0x82AA, 0x82AC, 0x82AE, 0x82B0, 0x82B2,
+    0x82B4, 0x82B6, 0x82B8, 0x82BA, 0x82BC,
+    0x82BE, 0x82C0, 0x82C3, 0x82C5, 0x82C7,
+    0x82CE, 0x82D1, 0x82D4, 0x82D7, 0x82DA
+};
+
+static const uint16_t handakuten_hiragana[] = {
+    0x82CF, 0x82D2, 0x82D5, 0x82D8, 0x82DB
+};
+
+static const uint16_t small_hiragana[] = {
+    0x829F, 0x82A1, 0x82A3, 0x82A5, 0x82A7,
+    0x82E1, 0x82E3, 0x82E5,
+    0x82C1
+};
+
+static const uint8_t status_label_hiragana[] = { 0x5B, 0x82, 0xA0, 0x5D, 0x00 };
+static const uint8_t status_label_katakana[] = { 0x5B, 0x83, 0x41, 0x5D, 0x00 };
+static const uint8_t status_label_fullwidth[] = { 0x5B, 0x82, 0x60, 0x5D, 0x00 };
+
+static bool ime_active = false;
+static bool prev_commodore_state = false;
+static bool prev_space_state = false;
+static bool ime_has_output = false;
+static bool is_verb_first = false;
+
+static uint8_t ime_input_mode = IME_MODE_HIRAGANA;
+static uint8_t ime_conversion_state = IME_STATE_INPUT;
+
+static uint8_t romaji_state = ROMAJI_EMPTY;
+static uint8_t last_consonant = 0;
+static uint8_t second_consonant = 0;
+static uint8_t romaji_buffer[ROMAJI_BUFFER_SIZE];
+static uint8_t romaji_pos = 0;
+static uint8_t hiragana_buffer[HIRAGANA_BUFFER_SIZE];
+static uint8_t hiragana_pos = 0;
+
+static uint8_t conversion_key_buffer[CONVERSION_KEY_SIZE];
+static uint8_t conversion_key_length = 0;
+
+static uint8_t saved_cursor_x = 0;
+static uint8_t saved_cursor_y = 0;
+static uint8_t saved_color = 0;
+static uint8_t passthrough_key = 0;
+
+static uint8_t candidates_buffer[CANDIDATE_BUFFER_SIZE];
+static uint8_t candidate_offsets[MAX_CANDIDATES];
+static uint8_t candidate_buffer_pos = 0;
+static uint8_t candidate_count = 0;
+static uint8_t current_candidate = 0;
+
+static uint8_t ime_output_buffer[128];
+static uint8_t ime_output_length = 0;
+
+static uint8_t prev_display_length = 0;
+static uint8_t prev_display_chars = 0;
+static uint8_t prev_romaji_pos = 0;
+
+static uint8_t current_entry_length = 0;
+
+static uint8_t current_bank = IME_DICTIONARY_START_BANK;
+static uint16_t current_offset = 0;
+
+static uint8_t verb_match_length = 0;
+static uint8_t verb_match_bank = 0;
+static uint16_t verb_match_offset = 0;
+static uint16_t verb_match_okurigana = 0;
+static uint8_t verb_candidate_count = 0;
+
+static uint8_t match_length = 0;
+static uint8_t match_bank = 0;
+static uint16_t match_offset = 0;
+static uint16_t match_okurigana = 0;
+static uint8_t match_candidate_count = 0;
+
+static void clear_romaji_buffer(void);
+static void clear_hiragana_buffer(void);
+static bool input_romaji(uint8_t key);
+static bool handle_empty_state(uint8_t key);
+static bool handle_consonant_state(uint8_t key);
+static bool handle_n_state(uint8_t key);
+static bool handle_small_tsu_state(uint8_t key);
+static bool handle_waiting_2nd_state(uint8_t key);
+static bool handle_x_prefix_state(uint8_t key);
+static bool handle_y_waiting_state(uint8_t key);
+static bool handle_skip_next_state(uint8_t key);
+static void force_confirm_romaji(void);
+static bool backspace_romaji(void);
+static void recalculate_state(void);
+static void add_to_hiragana_buffer(uint16_t sjis_char);
+static void add_small_tsu(void);
+static void add_n(void);
+static uint8_t vowel_index(uint8_t ch);
+static uint8_t consonant_to_row(uint8_t ch);
+static uint16_t convert_special_2char(uint8_t ch1, uint8_t ch2);
+static uint16_t convert_special_1char(uint8_t consonant, uint8_t vowel);
+static uint16_t convert_basic(uint8_t consonant, uint8_t vowel);
+static uint16_t convert_dakuten(uint8_t consonant, uint8_t vowel);
+static uint16_t convert_handakuten(uint8_t consonant, uint8_t vowel);
+static uint16_t convert_small(uint8_t vowel_or_y);
+static uint16_t convert_youon(uint8_t consonant, uint8_t y_vowel);
+static uint16_t convert_special_youon(uint8_t ch1, uint8_t ch2, uint8_t y_vowel);
+static void convert_to_katakana(uint8_t* target_ptr);
+static void convert_to_hiragana(uint8_t* target_ptr);
+static bool is_commodore_pressed(void);
+static bool is_space_pressed(void);
+static bool is_f1_pressed(void);
+static bool is_f3_pressed(void);
+static bool is_f5_pressed(void);
+static bool check_commodore_space(void);
+static void activate_ime_input(void);
+static void deactivate_ime_input_internal(void);
+static void clear_ime_input_line(void);
+static void show_ime_status(void);
+static bool process_ime_key(uint8_t key);
+static void input_ime_char(uint8_t key);
+static void backspace_ime_input(void);
+static void confirm_ime_input(void);
+static void cancel_ime_input_internal(void);
+static void update_ime_display(void);
+static void display_input_text(void);
+static void display_conversion_candidates(void);
+static const uint8_t* get_ime_output_internal(void);
+static uint8_t get_ime_output_length_internal(void);
+static void clear_ime_output_internal(void);
+static void clear_ime_input_area(void);
+static void clear_conversion_key_buffer(void);
+static uint8_t bytes_to_chars(uint8_t byte_length);
+static void jtxt_bput_number(uint8_t value);
+static uint8_t read_rom_byte(uint8_t bank, uint16_t offset);
+static uint8_t read_dic_byte(void);
+static uint8_t read_dic_string(uint8_t* buffer);
+static uint8_t hiragana_to_index(uint8_t first_byte, uint8_t second_byte);
+static bool check_okurigana_match(const uint8_t* okurigana_buffer, uint8_t verb_suffix);
+static bool search_noun_entries(const uint8_t* key_buffer, uint8_t key_length);
+static bool search_verb_entries(const uint8_t* key_buffer, uint8_t key_length);
+static bool search_entries_in_group(const uint8_t* key_buffer, uint8_t key_length, bool is_verb_search);
+static void add_candidates(uint16_t okurigana);
+static bool start_conversion(void);
+static void next_candidate(void);
+static void prev_candidate(void);
+static uint8_t* get_current_candidate(void);
+static void confirm_conversion(void);
+static void cancel_conversion(void);
+static void backup_cursor(void);
+static void restore_cursor(void);
+static uint8_t check_mode_keys(void);
+static uint8_t petscii_to_ascii(uint8_t key);
+static uint8_t vowel_index(uint8_t ch) {
+    switch (ch) {
+        case 'a': return 0;
+        case 'i': return 1;
+        case 'u': return 2;
+        case 'e': return 3;
+        case 'o': return 4;
+        default:  return 0xFF;
+    }
+}
+
+static uint8_t consonant_to_row(uint8_t ch) {
+    switch (ch) {
+        case 'k': return 1;
+        case 's': return 2;
+        case 't':
+        case 'c': return 3;
+        case 'n': return 4;
+        case 'h':
+        case 'f': return 5;
+        case 'm': return 6;
+        case 'y': return 7;
+        case 'r': return 8;
+        case 'w': return 9;
+        default:  return 0xFF;
+    }
+}
+
+static uint16_t convert_special_2char(uint8_t ch1, uint8_t ch2) {
+    if (ch1 == 's' && ch2 == 'h') {
+        return 0x82B5;
+    }
+    if (ch1 == 'c' && ch2 == 'h') {
+        return 0x82BF;
+    }
+    if (ch1 == 't' && ch2 == 's') {
+        return 0x82C2;
+    }
+    return 0;
+}
+
+static uint16_t convert_special_1char(uint8_t consonant, uint8_t vowel) {
+    switch (consonant) {
+        case 's':
+            if (vowel == 'i') {
+                return 0x82B5;
+            }
+            break;
+        case 't':
+            if (vowel == 'i') {
+                return 0x82BF;
+            }
+            if (vowel == 'u') {
+                return 0x82C2;
+            }
+            break;
+        case 'h':
+            if (vowel == 'u') {
+                return 0x82D3;
+            }
+            break;
+        case 'f':
+            switch (vowel) {
+                case 'a':
+                    add_to_hiragana_buffer(0x82D3);
+                    add_to_hiragana_buffer(0x829F);
+                    return 0xFFFF;
+                case 'i':
+                    add_to_hiragana_buffer(0x82D3);
+                    add_to_hiragana_buffer(0x82A1);
+                    return 0xFFFF;
+                case 'u':
+                    return 0x82D3;
+                case 'e':
+                    add_to_hiragana_buffer(0x82D3);
+                    add_to_hiragana_buffer(0x82A5);
+                    return 0xFFFF;
+                case 'o':
+                    add_to_hiragana_buffer(0x82D3);
+                    add_to_hiragana_buffer(0x82A7);
+                    return 0xFFFF;
+                default:
+                    break;
+            }
+            break;
+        default:
+            break;
+    }
+    return 0;
+}
+
+static uint16_t convert_basic(uint8_t consonant, uint8_t vowel) {
+    uint8_t row = consonant_to_row(consonant);
+    uint8_t vol = vowel_index(vowel);
+
+    if (row == 0xFF || vol == 0xFF) {
+        return 0;
+    }
+
+    if (row == 7) {
+        switch (vol) {
+            case 0: return basic_hiragana[35];
+            case 2: return basic_hiragana[36];
+            case 4: return basic_hiragana[37];
+            default: return 0;
+        }
+    }
+
+    if (row == 9) {
+        switch (vol) {
+            case 0:
+                return basic_hiragana[43];
+            case 1:
+                add_to_hiragana_buffer(0x82A4);
+                add_to_hiragana_buffer(0x82A1);
+                return 0xFFFF;
+            case 3:
+                add_to_hiragana_buffer(0x82A4);
+                add_to_hiragana_buffer(0x82A5);
+                return 0xFFFF;
+            case 4:
+                return basic_hiragana[44];
+            default:
+                return 0;
+        }
+    }
+
+    if (row >= 1 && row <= 8 && row != 7) {
+        uint8_t index;
+        if (row < 7) {
+            index = (uint8_t)((row - 1) * 5 + 5 + vol);
+        } else {
+            index = (uint8_t)(38 + vol);
+        }
+        return basic_hiragana[index];
+    }
+
+    return 0;
+}
+
+static uint16_t convert_dakuten(uint8_t consonant, uint8_t vowel) {
+    uint8_t vol = vowel_index(vowel);
+    uint8_t base = 0xFF;
+
+    if (vol > 4) {
+        return 0;
+    }
+    switch (consonant) {
+        case 'g': base = 0; break;
+        case 'z': base = 5; break;
+        case 'd': base = 10; break;
+        case 'b': base = 15; break;
+        default: break;
+    }
+
+    if (base == 0xFF) {
+        return 0;
+    }
+    return dakuten_hiragana[base + vol];
+}
+
+static uint16_t convert_handakuten(uint8_t consonant, uint8_t vowel) {
+    uint8_t vol;
+
+    if (consonant == 'p') {
+        vol = vowel_index(vowel);
+        if (vol <= 4) {
+            return handakuten_hiragana[vol];
+        }
+    }
+    return 0;
+}
+
+static uint16_t convert_small(uint8_t vowel_or_y) {
+    switch (vowel_or_y) {
+        case 'a': return small_hiragana[0];
+        case 'i': return small_hiragana[1];
+        case 'u': return small_hiragana[2];
+        case 'e': return small_hiragana[3];
+        case 'o': return small_hiragana[4];
+        case 'y': return small_hiragana[5];
+        default:  return 0;
+    }
+}
+
+static uint16_t convert_youon(uint8_t consonant, uint8_t y_vowel) {
+    uint16_t base_i = 0;
+    uint16_t small_ya = 0;
+    uint8_t base_index = 0;
+
+    switch (consonant) {
+        case 'k': base_index = 6; break;
+        case 's': base_index = 11; break;
+        case 't': base_index = 16; break;
+        case 'n': base_index = 21; break;
+        case 'h': base_index = 26; break;
+        case 'f': base_index = 27; break;
+        case 'm': base_index = 31; break;
+        case 'r': base_index = 39; break;
+        case 'g': base_index = (uint8_t)(1 | 0x40); break;
+        case 'z': base_index = (uint8_t)(6 | 0x40); break;
+        case 'j': base_index = (uint8_t)(6 | 0x40); break;
+        case 'd': base_index = (uint8_t)(11 | 0x40); break;
+        case 'b': base_index = (uint8_t)(16 | 0x40); break;
+        case 'p': base_index = (uint8_t)(1 | 0x80); break;
+        default: return 0;
+    }
+
+    switch (base_index & 0xC0) {
+        case 0x00:
+            base_i = basic_hiragana[base_index & 0x3F];
+            break;
+        case 0x40:
+            base_i = dakuten_hiragana[base_index & 0x3F];
+            break;
+        case 0x80:
+            base_i = handakuten_hiragana[base_index & 0x3F];
+            break;
+        default:
+            base_i = 0;
+            break;
+    }
+
+    if (base_i == 0) {
+        return 0;
+    }
+    switch (y_vowel) {
+        case 'a': small_ya = small_hiragana[5]; break;
+        case 'u': small_ya = small_hiragana[6]; break;
+        case 'o': small_ya = small_hiragana[7]; break;
+        default: return 0;
+    }
+
+    add_to_hiragana_buffer(base_i);
+    add_to_hiragana_buffer(small_ya);
+    return 0xFFFF;
+}
+
+static uint16_t convert_special_youon(uint8_t ch1, uint8_t ch2, uint8_t y_vowel) {
+    uint16_t base = 0;
+    uint16_t small_ya = 0;
+
+    if (ch1 == 'c' && ch2 == 'h') {
+        base = 0x82BF;
+    } else if (ch1 == 's' && ch2 == 'h') {
+        base = 0x82B5;
+    } else {
+        return 0;
+    }
+    switch (y_vowel) {
+        case 'a': small_ya = small_hiragana[5]; break;
+        case 'u': small_ya = small_hiragana[6]; break;
+        case 'o': small_ya = small_hiragana[7]; break;
+        default: return 0;
+    }
+
+    add_to_hiragana_buffer(base);
+    add_to_hiragana_buffer(small_ya);
+    return 0xFFFF;
+}
+
+static void add_to_hiragana_buffer(uint16_t sjis_char) {
+    uint8_t high;
+    uint8_t low;
+
+    if (hiragana_pos >= HIRAGANA_BUFFER_LIMIT) {
+        return;
+    }
+
+    high = msb16(sjis_char);
+    low = lsb16(sjis_char);
+
+    if (ime_input_mode == IME_MODE_KATAKANA) {
+        if (high >= 0x82 && low >= 0x9F && low <= 0xF1) {
+            high = 0x83;
+            if (low <= 0xDD) {
+                low = (uint8_t)(low - 0x5F);
+            } else {
+                low = (uint8_t)(low - 0x5E);
+            }
+        }
+    }
+
+    hiragana_buffer[hiragana_pos] = high;
+    hiragana_buffer[hiragana_pos + 1] = low;
+    hiragana_pos = (uint8_t)(hiragana_pos + 2);
+}
+
+static void add_small_tsu(void) {
+    add_to_hiragana_buffer(small_hiragana[8]);
+}
+
+static void add_n(void) {
+    add_to_hiragana_buffer(basic_hiragana[45]);
+}
+static void clear_romaji_buffer(void) {
+    romaji_pos = 0;
+    romaji_state = ROMAJI_EMPTY;
+    last_consonant = 0;
+    second_consonant = 0;
+    memset(romaji_buffer, 0, sizeof(romaji_buffer));
+}
+
+static void clear_hiragana_buffer(void) {
+    hiragana_pos = 0;
+    memset(hiragana_buffer, 0, sizeof(hiragana_buffer));
+}
+
+static void clear_conversion_key_buffer(void) {
+    memset(conversion_key_buffer, 0, sizeof(conversion_key_buffer));
+}
+static void debug_print_state(uint8_t key) {
+    (void)key;
+}
+static bool input_romaji(uint8_t key) {
+    if (key < 32 || key > 126) {
+        return false;
+    }
+
+    if (romaji_pos >= ROMAJI_BUFFER_SIZE - 1) {
+        force_confirm_romaji();
+    }
+
+    romaji_buffer[romaji_pos++] = key;
+
+    debug_print_state(key);
+
+    switch (romaji_state) {
+        case ROMAJI_EMPTY:
+            return handle_empty_state(key);
+        case ROMAJI_CONSONANT:
+            return handle_consonant_state(key);
+        case ROMAJI_N:
+            return handle_n_state(key);
+        case ROMAJI_SMALL_TSU:
+            return handle_small_tsu_state(key);
+        case ROMAJI_WAITING_2ND:
+            return handle_waiting_2nd_state(key);
+        case ROMAJI_X_PREFIX:
+            return handle_x_prefix_state(key);
+        case ROMAJI_Y_WAITING:
+            return handle_y_waiting_state(key);
+        case ROMAJI_SKIP_NEXT:
+            return handle_skip_next_state(key);
+        default:
+            clear_romaji_buffer();
+            return false;
+    }
+}
+static bool handle_empty_state(uint8_t key) {
+    uint8_t vol;
+    uint8_t row;
+
+    switch (key) {
+        case '-':
+            add_to_hiragana_buffer(0x815B);
+            clear_romaji_buffer();
+            return true;
+        case ',':
+            add_to_hiragana_buffer(0x8141);
+            clear_romaji_buffer();
+            return true;
+        case '.':
+            add_to_hiragana_buffer(0x8142);
+            clear_romaji_buffer();
+            return true;
+        default:
+            break;
+    }
+
+    vol = vowel_index(key);
+    if (vol != 0xFF) {
+        add_to_hiragana_buffer(basic_hiragana[vol]);
+        clear_romaji_buffer();
+        return true;
+    }
+
+    if (key == 'n') {
+        romaji_state = ROMAJI_N;
+        last_consonant = 'n';
+        return true;
+    }
+
+    if (key == 'x') {
+        romaji_state = ROMAJI_X_PREFIX;
+        return true;
+    }
+
+    row = consonant_to_row(key);
+    if (row != 0xFF || key == 'g' || key == 'z' || key == 'd' ||
+        key == 'b' || key == 'p' || key == 'j') {
+        if (key == 's' || key == 'c' || key == 't' || key == 'f' || key == 'd') {
+            romaji_state = ROMAJI_WAITING_2ND;
+            last_consonant = key;
+            return true;
+        }
+
+        romaji_state = ROMAJI_CONSONANT;
+        last_consonant = key;
+        return true;
+    }
+
+    clear_romaji_buffer();
+    return false;
+}
+static bool handle_consonant_state(uint8_t key) {
+    uint8_t vol;
+    uint16_t result = 0;
+
+    if (key == last_consonant && key != 'n') {
+        add_small_tsu();
+        romaji_state = ROMAJI_CONSONANT;
+        return true;
+    }
+
+    if (last_consonant == 'j') {
+        if (key == 'i') {
+            add_to_hiragana_buffer(0x82B6);
+            clear_romaji_buffer();
+            return true;
+        }
+        if (key == 'a' || key == 'u' || key == 'o') {
+            add_to_hiragana_buffer(0x82B6);
+            switch (key) {
+                case 'a': add_to_hiragana_buffer(0x82E1); break;
+                case 'u': add_to_hiragana_buffer(0x82E3); break;
+                case 'o': add_to_hiragana_buffer(0x82E5); break;
+            }
+            clear_romaji_buffer();
+            return true;
+        }
+        if (key == 'e') {
+            add_to_hiragana_buffer(0x82B6);
+            add_to_hiragana_buffer(0x82A5);
+            clear_romaji_buffer();
+            return true;
+        }
+        if (key == 'y') {
+            romaji_state = ROMAJI_Y_WAITING;
+            return true;
+        }
+        clear_romaji_buffer();
+        return false;
+    }
+
+    vol = vowel_index(key);
+    if (vol != 0xFF) {
+        result = convert_special_1char(last_consonant, key);
+        if (result == 0) {
+            result = convert_dakuten(last_consonant, key);
+            if (result == 0) {
+                result = convert_handakuten(last_consonant, key);
+                if (result == 0) {
+                    result = convert_basic(last_consonant, key);
+                }
+            }
+        }
+
+        if (result != 0) {
+            if (result != 0xFFFF) {
+                add_to_hiragana_buffer(result);
+            }
+            clear_romaji_buffer();
+            return true;
+        }
+    }
+
+    if (key == 'y') {
+        romaji_state = ROMAJI_Y_WAITING;
+        return true;
+    }
+
+    clear_romaji_buffer();
+    return false;
+}
+static bool handle_n_state(uint8_t key) {
+    uint8_t row;
+    uint8_t vol;
+    uint16_t result;
+
+    if (key == 'n') {
+        add_n();
+        clear_romaji_buffer();
+        return true;
+    }
+
+    row = consonant_to_row(key);
+    if (row != 0xFF && key != 'y') {
+        add_n();
+        clear_romaji_buffer();
+        return input_romaji(key);
+    }
+
+    if (key == 'j' || key == 'g' || key == 'z' || key == 'd' || key == 'b' || key == 'p') {
+        add_n();
+        clear_romaji_buffer();
+        return input_romaji(key);
+    }
+
+    vol = vowel_index(key);
+    if (vol != 0xFF) {
+        result = convert_basic('n', key);
+        if (result != 0) {
+            if (result != 0xFFFF) {
+                add_to_hiragana_buffer(result);
+            }
+            clear_romaji_buffer();
+            return true;
+        }
+    }
+
+    if (key == 'y') {
+        romaji_state = ROMAJI_Y_WAITING;
+        return true;
+    }
+
+    clear_romaji_buffer();
+    return false;
+}
+static bool handle_small_tsu_state(uint8_t key) {
+    clear_romaji_buffer();
+    return input_romaji(key);
+}
+static bool handle_waiting_2nd_state(uint8_t key) {
+    if (key == last_consonant) {
+        add_small_tsu();
+        return true;
+    }
+
+    if (key == 'h') {
+        second_consonant = key;
+        romaji_state = ROMAJI_Y_WAITING;
+        return true;
+    }
+
+    if (last_consonant == 't' && key == 's') {
+        add_to_hiragana_buffer(0x82C2);
+        clear_romaji_buffer();
+        romaji_state = ROMAJI_SKIP_NEXT;
+        return true;
+    }
+
+    romaji_state = ROMAJI_CONSONANT;
+    return handle_consonant_state(key);
+}
+
+static bool handle_x_prefix_state(uint8_t key) {
+    uint16_t result = convert_small(key);
+    if (result != 0) {
+        add_to_hiragana_buffer(result);
+        clear_romaji_buffer();
+        return true;
+    }
+
+    clear_romaji_buffer();
+    return false;
+}
+static bool handle_y_waiting_state(uint8_t key) {
+    uint8_t vol;
+    uint16_t result;
+
+    result = 0;
+
+    if (second_consonant == 'h') {
+        vol = vowel_index(key);
+        if (vol != 0xFF) {
+            switch (key) {
+                case 'i':
+                    if (last_consonant == 'd') {
+                        add_to_hiragana_buffer(0x82C5);
+                        add_to_hiragana_buffer(0x82A1);
+                        clear_romaji_buffer();
+                        return true;
+                    }
+                    result = convert_special_2char(last_consonant, second_consonant);
+                    if (result != 0) {
+                        add_to_hiragana_buffer(result);
+                        clear_romaji_buffer();
+                        return true;
+                    }
+                    break;
+                case 'a':
+                case 'u':
+                case 'o':
+                    if (last_consonant == 'd') {
+                        add_to_hiragana_buffer(0x82C5);
+                        if (key == 'a') {
+                            add_to_hiragana_buffer(0x82E1);
+                        } else if (key == 'u') {
+                            add_to_hiragana_buffer(0x82E3);
+                        } else {
+                            add_to_hiragana_buffer(0x82E5);
+                        }
+                        clear_romaji_buffer();
+                        return true;
+                    }
+                    result = convert_special_youon(last_consonant, second_consonant, key);
+                    if (result != 0) {
+                        clear_romaji_buffer();
+                        return true;
+                    }
+                    break;
+                case 'e':
+                    if (last_consonant == 'd') {
+                        add_to_hiragana_buffer(0x82C5);
+                        add_to_hiragana_buffer(0x82A5);
+                        clear_romaji_buffer();
+                        return true;
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+    } else {
+        if (key == 'a' || key == 'u' || key == 'o') {
+            result = convert_youon(last_consonant, key);
+            if (result != 0) {
+                clear_romaji_buffer();
+                return true;
+            }
+        }
+    }
+
+    clear_romaji_buffer();
+    return false;
+}
+
+static bool handle_skip_next_state(uint8_t key) {
+    (void)key;
+    clear_romaji_buffer();
+    return true;
+}
+static void force_confirm_romaji(void) {
+    if (romaji_state == ROMAJI_N) {
+        add_n();
+    }
+    clear_romaji_buffer();
+}
+
+static bool backspace_romaji(void) {
+    if (romaji_pos == 0) {
+        if (hiragana_pos >= 2) {
+            hiragana_pos = (uint8_t)(hiragana_pos - 2);
+            hiragana_buffer[hiragana_pos] = 0;
+            hiragana_buffer[hiragana_pos + 1] = 0;
+            return true;
+        }
+        return false;
+    }
+
+    if (romaji_pos > 0) {
+        romaji_buffer[--romaji_pos] = 0;
+        recalculate_state();
+        return true;
+    }
+
+    return false;
+}
+
+static void recalculate_state(void) {
+    uint8_t last_char;
+    uint8_t saved_char;
+
+    if (romaji_pos == 0) {
+        clear_romaji_buffer();
+        return;
+    }
+
+    last_char = romaji_buffer[romaji_pos - 1];
+
+    if (romaji_pos == 1) {
+        if (last_char == 'n') {
+            romaji_state = ROMAJI_N;
+            last_consonant = 'n';
+        } else if (last_char == 'x') {
+            romaji_state = ROMAJI_X_PREFIX;
+            last_consonant = 0;
+            second_consonant = 0;
+        } else if (last_char == 's' || last_char == 'c' || last_char == 't' ||
+                   last_char == 'f' || last_char == 'd') {
+            romaji_state = ROMAJI_WAITING_2ND;
+            last_consonant = last_char;
+            second_consonant = 0;
+        } else {
+            uint8_t row = consonant_to_row(last_char);
+            if (row != 0xFF || last_char == 'g' || last_char == 'z' ||
+                last_char == 'd' || last_char == 'b' || last_char == 'p' ||
+                last_char == 'j') {
+                romaji_state = ROMAJI_CONSONANT;
+                last_consonant = last_char;
+                second_consonant = 0;
+            } else {
+                clear_romaji_buffer();
+            }
+        }
+        return;
+    }
+
+    if (romaji_pos == 2) {
+        uint8_t first_char = romaji_buffer[0];
+
+        if ((first_char == 's' && last_char == 'h') ||
+            (first_char == 'c' && last_char == 'h') ||
+            (first_char == 't' && last_char == 's')) {
+            romaji_state = ROMAJI_Y_WAITING;
+            last_consonant = first_char;
+            second_consonant = last_char;
+            return;
+        }
+
+        if (last_char == 'y') {
+            romaji_state = ROMAJI_Y_WAITING;
+            last_consonant = first_char;
+            second_consonant = 0;
+            return;
+        }
+
+        romaji_state = ROMAJI_CONSONANT;
+        last_consonant = first_char;
+        second_consonant = 0;
+        return;
+    }
+
+    saved_char = last_char;
+    clear_romaji_buffer();
+    romaji_buffer[0] = saved_char;
+    romaji_pos = 1;
+    recalculate_state();
+}
+static void convert_to_katakana(uint8_t* target_ptr) {
+    uint8_t i = 0;
+    uint8_t ch;
+    while (target_ptr[i] != 0) {
+        if (target_ptr[i] < 0x80) {
+            ++i;
+            continue;
+        }
+        ch = target_ptr[i + 1];
+        if (target_ptr[i] >= 0x82 && ch >= 0x9F && ch <= 0xF1) {
+            target_ptr[i] = 0x83;
+            if (ch <= 0xDD) {
+                target_ptr[i + 1] = (uint8_t)(ch - 0x5F);
+            } else {
+                target_ptr[i + 1] = (uint8_t)(ch - 0x5E);
+            }
+        }
+        i = (uint8_t)(i + 2);
+    }
+}
+
+static void convert_to_hiragana(uint8_t* target_ptr) {
+    uint8_t i = 0;
+    uint8_t ch;
+    while (target_ptr[i] != 0) {
+        if (target_ptr[i] < 0x80) {
+            ++i;
+            continue;
+        }
+        ch = target_ptr[i + 1];
+        if (target_ptr[i] == 0x83 && ch >= 0x40 && ch <= 0x93) {
+            target_ptr[i] = 0x82;
+            if (ch <= 0x7E) {
+                target_ptr[i + 1] = (uint8_t)(ch + 0x5F);
+            } else {
+                target_ptr[i + 1] = (uint8_t)(ch + 0x5E);
+            }
+        }
+        i = (uint8_t)(i + 2);
+    }
+}
+static bool is_commodore_pressed(void) {
+    uint8_t result;
+
+    POKE(CIA1_DATA_A, COMMODORE_ROW);
+    result = PEEK(CIA1_DATA_B);
+    return (result & COMMODORE_BIT) == 0;
+}
+
+static bool is_space_pressed(void) {
+    uint8_t result;
+
+    POKE(CIA1_DATA_A, SPACE_ROW);
+    result = PEEK(CIA1_DATA_B);
+    return (result & SPACE_BIT) == 0;
+}
+
+static bool is_f1_pressed(void) {
+    uint8_t result;
+
+    POKE(CIA1_DATA_A, FKEY_ROW);
+    result = PEEK(CIA1_DATA_B);
+    return (result & F1_BIT) == 0;
+}
+
+static bool is_f3_pressed(void) {
+    uint8_t result;
+
+    POKE(CIA1_DATA_A, FKEY_ROW);
+    result = PEEK(CIA1_DATA_B);
+    return (result & F3_BIT) == 0;
+}
+
+static bool is_f5_pressed(void) {
+    uint8_t result;
+
+    POKE(CIA1_DATA_A, FKEY_ROW);
+    result = PEEK(CIA1_DATA_B);
+    return (result & F5_BIT) == 0;
+}
+
+static bool check_commodore_space(void) {
+    bool current_commodore = is_commodore_pressed();
+    bool current_space = is_space_pressed();
+
+    bool trigger = false;
+    if (current_commodore && current_space && !prev_space_state) {
+        trigger = true;
+    }
+
+    prev_commodore_state = current_commodore;
+    prev_space_state = current_space;
+
+    return trigger;
+}
+static void clear_ime_input_line(void) {
+    jtxt_bwindow_disable();
+    jtxt_bcolor(COLOR_DEFAULT_FG, COLOR_DEFAULT_BG);
+    jtxt_blocate(0, 24);
+    {
+        uint8_t i;
+        for (i = 0; i < 40; ++i) {
+            jtxt_bputc(32);
+        }
+    }
+
+    prev_display_length = 0;
+    prev_display_chars = 0;
+    prev_romaji_pos = 0;
+
+    if (ime_active) {
+        jtxt_bwindow_enable();
+    }
+}
+
+static void show_ime_status(void) {
+    const uint8_t* label = status_label_hiragana;
+
+    if (!ime_active) {
+        return;
+    }
+
+    switch (ime_input_mode) {
+        case IME_MODE_KATAKANA:
+            label = status_label_katakana;
+            break;
+        case IME_MODE_FULLWIDTH:
+            label = status_label_fullwidth;
+            break;
+        default:
+            label = status_label_hiragana;
+            break;
+    }
+
+    jtxt_bwindow_disable();
+    jtxt_blocate(37, 24);
+    jtxt_bcolor(COLOR_STATUS_FG, COLOR_STATUS_BG);
+    jtxt_bputs((const char*)label);
+    jtxt_bcolor(COLOR_DEFAULT_FG, COLOR_DEFAULT_BG);
+    jtxt_bwindow_enable();
+}
+
+static void activate_ime_input(void) {
+    jtxt_bwindow(0, 23);
+    clear_ime_input_line();
+    show_ime_status();
+}
+
+static void deactivate_ime_input_internal(void) {
+    jtxt_bwindow_disable();
+    clear_ime_input_line();
+    clear_romaji_buffer();
+    clear_hiragana_buffer();
+    ime_conversion_state = IME_STATE_INPUT;
+    candidate_count = 0;
+    current_candidate = 0;
+    conversion_key_length = 0;
+    candidate_buffer_pos = 0;
+    verb_candidate_count = 0;
+    match_candidate_count = 0;
+    passthrough_key = 0;
+}
+
+static void clear_ime_input_area(void) {
+    jtxt_bwindow_disable();
+    jtxt_bcolor(COLOR_DEFAULT_FG, COLOR_DEFAULT_BG);
+    jtxt_blocate(0, 24);
+    {
+        uint8_t i;
+        for (i = 0; i < 37; ++i) {
+            jtxt_bputc(32);
+        }
+    }
+    if (ime_active) {
+        jtxt_bwindow_enable();
+    }
+}
+
+static uint8_t bytes_to_chars(uint8_t byte_length) {
+    uint8_t char_count;
+    uint8_t i;
+
+    if (byte_length == 0) {
+        return 0;
+    }
+
+    char_count = 0;
+    i = 0;
+    while (i < byte_length) {
+        if (jtxt_is_firstsjis(hiragana_buffer[i])) {
+            ++char_count;
+            i = (uint8_t)(i + 2);
+        } else {
+            ++char_count;
+            ++i;
+        }
+    }
+
+    return char_count;
+}
+static const uint8_t* get_ime_output_internal(void) {
+    return ime_has_output ? ime_output_buffer : NULL;
+}
+
+static uint8_t get_ime_output_length_internal(void) {
+    return ime_has_output ? ime_output_length : 0;
+}
+
+static void clear_ime_output_internal(void) {
+    ime_has_output = false;
+    ime_output_length = 0;
+}
+static void update_ime_display(void) {
+    jtxt_bwindow_disable();
+    jtxt_bcolor(COLOR_DEFAULT_FG, COLOR_DEFAULT_BG);
+
+    if (ime_conversion_state == IME_STATE_INPUT) {
+        display_input_text();
+    } else {
+        display_conversion_candidates();
+    }
+
+    jtxt_bwindow_enable();
+}
+static void display_input_text(void) {
+    uint8_t current_length = hiragana_pos;
+    uint8_t current_chars = bytes_to_chars(current_length);
+    uint8_t current_romaji = romaji_pos;
+    uint8_t total_chars = (uint8_t)(current_chars + current_romaji);
+    uint8_t prev_total_chars = (uint8_t)(prev_display_chars + prev_romaji_pos);
+
+    bool needs_update = (current_length != prev_display_length) ||
+                        (current_romaji != prev_romaji_pos);
+
+    if (!needs_update) {
+        return;
+    }
+
+    if (total_chars < 37) {
+        uint8_t i;
+
+        jtxt_blocate(0, 24);
+
+        for (i = 0; i < current_length; ++i) {
+            jtxt_bputc(hiragana_buffer[i]);
+        }
+
+        for (i = 0; i < current_romaji; ++i) {
+            jtxt_bputc(romaji_buffer[i]);
+        }
+
+        if (total_chars < prev_total_chars) {
+            for (i = total_chars; i < prev_total_chars; ++i) {
+                jtxt_bputc(32);
+            }
+        }
+    }
+
+    prev_display_length = current_length;
+    prev_display_chars = current_chars;
+    prev_romaji_pos = current_romaji;
+}
+static void jtxt_bput_number(uint8_t value) {
+    char buffer[4];
+    uint8_t pos = 0;
+
+    if (value >= 100) {
+        buffer[pos++] = (char)('0' + (value / 100));
+        value %= 100;
+    }
+    if (value >= 10 || pos > 0) {
+        buffer[pos++] = (char)('0' + (value / 10));
+        value %= 10;
+    }
+    buffer[pos++] = (char)('0' + value);
+
+    {
+        uint8_t i;
+        for (i = 0; i < pos; ++i) {
+            jtxt_bputc((uint8_t)buffer[i]);
+        }
+    }
+}
+static void display_conversion_candidates(void) {
+    uint8_t* candidate_str;
+    uint8_t i;
+    uint8_t col;
+    uint8_t ch;
+
+    clear_ime_input_area();
+
+    if (candidate_count == 0) {
+        return;
+    }
+
+    jtxt_bwindow_disable();
+    jtxt_blocate(0, 24);
+
+    candidate_str = get_current_candidate();
+    if (candidate_str != NULL) {
+        i = 0;
+        col = 0;
+        while (candidate_str[i] != 0 && col < 20) {
+            ch = candidate_str[i];
+            jtxt_bputc(ch);
+            if (jtxt_is_firstsjis(ch)) {
+                ++i;
+                if (candidate_str[i] != 0) {
+                    jtxt_bputc(candidate_str[i]);
+                }
+                col = (uint8_t)(col + 2);
+            } else {
+                col = (uint8_t)(col + 1);
+            }
+            ++i;
+        }
+    }
+
+    jtxt_bputc(' ');
+    jtxt_bput_number((uint8_t)(current_candidate + 1));
+    jtxt_bputc('/');
+    jtxt_bput_number(candidate_count);
+
+    prev_display_length = 0;
+    prev_display_chars = 0;
+    prev_romaji_pos = 0;
+}
+static void input_ime_char(uint8_t key) {
+    uint8_t processed_key = key;
+    if (key >= 'A' && key <= 'Z') {
+        processed_key = (uint8_t)(key + 32);
+    }
+
+    bool converted = input_romaji(processed_key);
+
+    // input_romajiが失敗した場合も表示を更新
+    // （バッファがクリアされた状態を反映するため）
+    (void)converted;  // 現在は戻り値を使わないが、将来のために保持
+
+    update_ime_display();
+}
+
+static void backspace_ime_input(void) {
+    if (backspace_romaji()) {
+        update_ime_display();
+    }
+}
+
+static void confirm_ime_input(void) {
+    ime_output_length = hiragana_pos;
+    if (ime_output_length > sizeof(ime_output_buffer)) {
+        ime_output_length = sizeof(ime_output_buffer);
+    }
+
+    if (ime_output_length > 0) {
+        uint8_t i;
+        for (i = 0; i < ime_output_length; ++i) {
+            ime_output_buffer[i] = hiragana_buffer[i];
+        }
+        ime_has_output = true;
+    }
+
+    clear_romaji_buffer();
+    clear_hiragana_buffer();
+
+    prev_display_length = 0;
+    prev_display_chars = 0;
+    prev_romaji_pos = 0;
+
+    clear_ime_input_area();
+    update_ime_display();
+}
+
+static void cancel_ime_input_internal(void) {
+    clear_romaji_buffer();
+    clear_hiragana_buffer();
+
+    prev_display_length = 0;
+    prev_display_chars = 0;
+    prev_romaji_pos = 0;
+
+    update_ime_display();
+}
+static bool process_ime_key(uint8_t key) {
+    if (!ime_active) {
+        return false;
+    }
+
+    if (is_f1_pressed()) {
+        ime_set_hiragana_mode();
+        return true;
+    }
+    if (is_f3_pressed()) {
+        ime_set_katakana_mode();
+        return true;
+    }
+    if (is_f5_pressed()) {
+        ime_set_alphanumeric_mode();
+        return true;
+    }
+
+    switch (key) {
+        case KEY_RETURN:
+            if (ime_conversion_state == IME_STATE_INPUT) {
+                confirm_ime_input();
+            } else {
+                confirm_conversion();
+                update_ime_display();
+            }
+            return true;
+        case KEY_ESC:
+            if (ime_conversion_state == IME_STATE_INPUT) {
+                cancel_ime_input_internal();
+            } else {
+                cancel_conversion();
+            }
+            return true;
+        case 8:
+        case 20:
+            if (ime_conversion_state == IME_STATE_INPUT) {
+                backspace_ime_input();
+            } else {
+                cancel_conversion();
+                backspace_ime_input();
+            }
+            return true;
+        case KEY_SPACE:
+            if (ime_input_mode == IME_MODE_KATAKANA) {
+                input_ime_char(KEY_SPACE);
+            } else {
+                if (ime_conversion_state == IME_STATE_INPUT) {
+                    if (start_conversion()) {
+                        update_ime_display();
+                    } else {
+                        input_ime_char(KEY_SPACE);
+                    }
+                } else {
+                    next_candidate();
+                    update_ime_display();
+                }
+            }
+            return true;
+        case 160:
+            if (ime_input_mode != IME_MODE_KATAKANA &&
+                ime_conversion_state == IME_STATE_CONVERTING) {
+                prev_candidate();
+                update_ime_display();
+                return true;
+            }
+            return false;
+        default:
+            if (key >= 32 && key <= 126) {
+                if (ime_conversion_state == IME_STATE_INPUT) {
+                    input_ime_char(key);
+                } else {
+                    confirm_conversion();
+                    update_ime_display();
+                    input_ime_char(key);
+                }
+                return true;
+            }
+            break;
+    }
+
+    return false;
+}
+void ime_init(void) {
+    ime_active = false;
+    ime_input_mode = IME_MODE_HIRAGANA;
+
+    clear_romaji_buffer();
+    clear_hiragana_buffer();
+    clear_conversion_key_buffer();
+
+    prev_commodore_state = false;
+    prev_space_state = false;
+    prev_display_length = 0;
+    prev_display_chars = 0;
+    prev_romaji_pos = 0;
+    ime_has_output = false;
+    ime_output_length = 0;
+
+    ime_conversion_state = IME_STATE_INPUT;
+    candidate_count = 0;
+    current_candidate = 0;
+    conversion_key_length = 0;
+    candidate_buffer_pos = 0;
+    verb_candidate_count = 0;
+    match_candidate_count = 0;
+    passthrough_key = 0;
+}
+
+void ime_toggle_mode(void) {
+    ime_active = !ime_active;
+    if (ime_active) {
+        activate_ime_input();
+    } else {
+        deactivate_ime_input_internal();
+    }
+}
+
+bool ime_is_active(void) {
+    return ime_active;
+}
+
+void ime_set_hiragana_mode(void) {
+    ime_input_mode = IME_MODE_HIRAGANA;
+    if (hiragana_pos > 0) {
+        convert_to_hiragana(hiragana_buffer);
+        prev_display_chars = 0;
+        prev_display_length = 0;
+        prev_romaji_pos = 0;
+        update_ime_display();
+    }
+    if (ime_active) {
+        show_ime_status();
+    }
+}
+
+void ime_set_katakana_mode(void) {
+    ime_input_mode = IME_MODE_KATAKANA;
+    if (hiragana_pos > 0) {
+        convert_to_katakana(hiragana_buffer);
+        prev_display_chars = 0;
+        prev_display_length = 0;
+        prev_romaji_pos = 0;
+        update_ime_display();
+    }
+    if (ime_active) {
+        show_ime_status();
+    }
+}
+
+void ime_set_alphanumeric_mode(void) {
+    ime_input_mode = IME_MODE_FULLWIDTH;
+    if (ime_active) {
+        show_ime_status();
+    }
+}
+
+uint8_t ime_get_input_mode(void) {
+    return ime_input_mode;
+}
+
+void ime_activate(void) {
+    ime_active = true;
+    activate_ime_input();
+
+    jtxt_bwindow_enable();
+}
+
+void ime_deactivate(void) {
+    ime_active = false;
+    deactivate_ime_input_internal();
+    clear_ime_output_internal();
+}
+static void backup_cursor(void) {
+    saved_cursor_x = jtxt_state.cursor_x;
+    saved_cursor_y = jtxt_state.cursor_y;
+    saved_color = jtxt_state.bitmap_color;
+}
+
+static void restore_cursor(void) {
+    jtxt_blocate(saved_cursor_x, saved_cursor_y);
+    jtxt_bcolor(saved_color >> 4, saved_color & 0x0F);
+}
+uint8_t ime_process(void) {
+    uint8_t key;
+    uint8_t mode_event;
+    bool handled;
+    const uint8_t* output;
+    uint8_t length;
+
+    if (check_commodore_space()) {
+        backup_cursor();
+        if (ime_active) {
+            ime_deactivate();
+            restore_cursor();
+            return IME_EVENT_DEACTIVATED;
+        }
+        ime_activate();
+        restore_cursor();
+        return IME_EVENT_NONE;
+    }
+
+    if (!ime_active) {
+        return IME_EVENT_NONE;
+    }
+
+    key = (uint8_t)cbm_k_getin();
+    if (key == 0) {
+        return IME_EVENT_NONE;
+    }
+
+    backup_cursor();
+
+    key = petscii_to_ascii(key);
+
+    mode_event = check_mode_keys();
+    if (mode_event != IME_EVENT_NONE) {
+        restore_cursor();
+        return mode_event;
+    }
+
+    clear_ime_output_internal();
+
+    if (key == KEY_ESC) {
+        cancel_ime_input_internal();
+        restore_cursor();
+        return IME_EVENT_CANCELLED;
+    }
+
+    if ((key == 20 || key == KEY_RETURN) && romaji_pos == 0 && hiragana_pos == 0) {
+        passthrough_key = key;
+        restore_cursor();
+        return IME_EVENT_KEY_PASSTHROUGH;
+    }
+
+    handled = process_ime_key(key);
+    if (handled) {
+        output = get_ime_output_internal();
+        if (output != NULL) {
+            length = get_ime_output_length_internal();
+            if (length > 0) {
+                restore_cursor();
+                return IME_EVENT_CONFIRMED;
+            }
+        }
+    }
+
+    restore_cursor();
+    return IME_EVENT_NONE;
+}
+const uint8_t* ime_get_result_text(void) {
+    return get_ime_output_internal();
+}
+
+uint8_t ime_get_result_length(void) {
+    return get_ime_output_length_internal();
+}
+
+void ime_clear_output(void) {
+    clear_ime_output_internal();
+}
+
+uint8_t ime_get_passthrough_key(void) {
+    return passthrough_key;
+}
+static uint8_t check_mode_keys(void) {
+    if (is_f1_pressed()) {
+        ime_set_hiragana_mode();
+        return IME_EVENT_MODE_CHANGED;
+    }
+    if (is_f3_pressed()) {
+        ime_set_katakana_mode();
+        return IME_EVENT_MODE_CHANGED;
+    }
+    if (is_f5_pressed()) {
+        ime_set_alphanumeric_mode();
+        return IME_EVENT_MODE_CHANGED;
+    }
+    return IME_EVENT_NONE;
+}
+static uint8_t petscii_to_ascii(uint8_t key) {
+    uint8_t ascii = key;
+
+    if (ascii >= 128) {
+        ascii &= 0x7F;
+    }
+
+    switch (ascii) {
+        case 0x1D: // cursor right
+        case 0x11: // cursor down
+        case 0x0D: // return
+        case 0x14: // delete
+        case 0x1B: // escape
+            return ascii;
+        default:
+            break;
+    }
+
+    return ascii;
+}
+
+static uint8_t read_rom_byte(uint8_t bank, uint16_t offset) {
+    uint8_t saved_01;
+    uint8_t value;
+
+    saved_01 = PEEK(0x01);
+    POKE(0x01, saved_01 | 0x01);
+    POKE(BANK_REG, bank);
+    value = PEEK(ROM_BASE + offset);
+    POKE(0x01, saved_01);
+    return value;
+}
+
+static uint8_t read_dic_byte(void) {
+    uint8_t data = read_rom_byte(current_bank, current_offset);
+    ++current_offset;
+    if (current_offset >= 8192) {
+        current_offset = 0;
+        ++current_bank;
+    }
+    return data;
+}
+
+static uint8_t read_dic_string(uint8_t* buffer) {
+    uint8_t length = 0;
+    while (length < 63) {
+        uint8_t ch = read_dic_byte();
+        buffer[length] = ch;
+        if (ch == 0) {
+            return length;
+        }
+        ++length;
+    }
+    buffer[length] = 0;
+    return length;
+}
+
+
+static uint8_t hiragana_to_index(uint8_t first_byte, uint8_t second_byte) {
+    uint16_t ch = mkword(first_byte, second_byte);
+    if (ch < 0x82A0) {
+        return 0xFF;
+    }
+    ch = (uint16_t)(ch - 0x82A0);
+    if (ch <= 82) {
+        return (uint8_t)ch;
+    }
+    return 0xFF;
+}
+static bool check_okurigana_match(const uint8_t* okurigana_buffer, uint8_t verb_suffix) {
+    uint8_t second_byte;
+
+    if (okurigana_buffer[0] != 0x82) {
+        return false;
+    }
+    second_byte = okurigana_buffer[1];
+
+    switch (verb_suffix) {
+        case 'k':
+            return second_byte >= 0xA9 && second_byte <= 0xB1 && (second_byte & 1U) == 1U;
+        case 'g':
+            return second_byte >= 0xAA && second_byte <= 0xB2 && (second_byte & 1U) == 0U;
+        case 's':
+            return second_byte >= 0xB3 && second_byte <= 0xBB && (second_byte & 1U) == 1U;
+        case 'z':
+        case 'j':
+            return second_byte >= 0xB4 && second_byte <= 0xBC && (second_byte & 1U) == 0U;
+        case 't':
+            return second_byte == 0xBD || second_byte == 0xBF ||
+                   second_byte == 0xC1 || second_byte == 0xC2 ||
+                   second_byte == 0xC4 || second_byte == 0xC6;
+        case 'd':
+            return second_byte == 0xBE || second_byte == 0xC0 ||
+                   second_byte == 0xC3 || second_byte == 0xC5 ||
+                   second_byte == 0xC7;
+        case 'n':
+            return (second_byte >= 0xC8 && second_byte <= 0xCC) || second_byte == 0xF1;
+        case 'h':
+            return second_byte >= 0xCD && second_byte <= 0xD1;
+        case 'b':
+            return second_byte >= 0xD2 && second_byte <= 0xD6;
+        case 'p':
+            return second_byte >= 0xD7 && second_byte <= 0xDB;
+        case 'm':
+            return second_byte >= 0xDC && second_byte <= 0xE0;
+        case 'r':
+            return second_byte >= 0xE7 && second_byte <= 0xEB;
+        case 'w':
+            return second_byte == 0xED || second_byte == 0xF0 || second_byte == 0xA4;
+        case 'i':
+            return second_byte == 0xA2;
+        case 'u':
+            return second_byte == 0xA4;
+        case 'e':
+            return second_byte == 0xA6;
+        case 'o':
+            return second_byte == 0xA8;
+        default:
+            return false;
+    }
+}
+static bool search_noun_entries(const uint8_t* key_buffer, uint8_t key_length) {
+    uint8_t index;
+    uint8_t offset_low;
+    uint8_t offset_high;
+    uint8_t offset_bank;
+
+    if (key_length < 2) {
+        return false;
+    }
+
+    index = hiragana_to_index(key_buffer[0], key_buffer[1]);
+    if (index == 0xFF) {
+        return false;
+    }
+
+    current_bank = IME_DICTIONARY_START_BANK;
+    current_offset = (uint16_t)(4 + (uint16_t)index * 3U);
+
+    offset_low = read_dic_byte();
+    offset_high = read_dic_byte();
+    offset_bank = read_dic_byte();
+
+    if (offset_low == 0 && offset_high == 0 && offset_bank == 0) {
+        return false;
+    }
+
+    current_bank = (uint8_t)(IME_DICTIONARY_START_BANK + offset_bank);
+    current_offset = mkword(offset_high, offset_low);
+    return search_entries_in_group(key_buffer, key_length, false);
+}
+
+static bool search_verb_entries(const uint8_t* key_buffer, uint8_t key_length) {
+    uint8_t index;
+    uint8_t offset_low;
+    uint8_t offset_high;
+    uint8_t offset_bank;
+
+    if (key_length < 2) {
+        return false;
+    }
+
+    index = hiragana_to_index(key_buffer[0], key_buffer[1]);
+    if (index == 0xFF) {
+        return false;
+    }
+
+    current_bank = IME_DICTIONARY_START_BANK;
+    current_offset = (uint16_t)(250 + (uint16_t)index * 3U);
+
+    offset_low = read_dic_byte();
+    offset_high = read_dic_byte();
+    offset_bank = read_dic_byte();
+
+    if (offset_low == 0 && offset_high == 0 && offset_bank == 0) {
+        return false;
+    }
+
+    current_bank = (uint8_t)(IME_DICTIONARY_START_BANK + offset_bank);
+    current_offset = mkword(offset_high, offset_low);
+    return search_entries_in_group(key_buffer, key_length, true);
+}
+static bool search_entries_in_group(const uint8_t* key_buffer, uint8_t key_length, bool is_verb_search) {
+    uint8_t skip_low;
+    uint8_t skip_high;
+    uint16_t skip_size;
+    uint8_t prev_skip_high;
+
+    candidate_count = 0;
+
+    skip_low = read_dic_byte();
+    skip_high = read_dic_byte();
+    skip_size = (uint16_t)(mkword(skip_high, skip_low) & 0x7FFFU);
+
+    for (;;) {
+        uint8_t entry_key_buffer[64];
+        uint8_t entry_key_length;
+        bool should_check;
+        bool match;
+        uint8_t compare_length;
+        uint8_t last_char;
+
+        entry_key_length = read_dic_string(entry_key_buffer);
+
+        should_check = false;
+        if (is_verb_search) {
+            if (entry_key_length > 0 && entry_key_buffer[entry_key_length - 1] < 128) {
+                if (key_length >= (uint8_t)(entry_key_length - 1)) {
+                    should_check = true;
+                }
+            }
+        } else if (entry_key_length > 0 && key_length >= entry_key_length) {
+            should_check = true;
+        }
+
+        if (should_check) {
+            uint8_t okurigana_high = 0;
+            uint8_t okurigana_low = 0;
+
+
+            match = true;
+            compare_length = entry_key_length;
+
+            if (is_verb_search) {
+                compare_length = (uint8_t)(entry_key_length - 1);
+            }
+
+            {
+                uint8_t i;
+                for (i = 0; i < compare_length; ++i) {
+                    if (key_buffer[i] != entry_key_buffer[i]) {
+                        match = false;
+                        break;
+                    }
+                }
+            }
+
+            if (is_verb_search && match) {
+                last_char = entry_key_buffer[compare_length];
+                if (last_char < 128) {
+                    match = check_okurigana_match(&key_buffer[compare_length], last_char);
+                    entry_key_length = (uint8_t)(compare_length + 1);
+                } else {
+                    match = false;
+                }
+            }
+
+            if (match) {
+                match_length = entry_key_length;
+                match_bank = current_bank;
+                match_offset = current_offset;
+                match_okurigana = 0;
+
+                current_entry_length = entry_key_length;
+                if (is_verb_search) {
+                    ++current_entry_length;
+                    if (key_length > (uint8_t)(entry_key_length - 1) && key_length > entry_key_length) {
+                        okurigana_high = key_buffer[entry_key_length - 1];
+                        okurigana_low = key_buffer[entry_key_length];
+                        match_okurigana = mkword(okurigana_high, okurigana_low);
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        {
+            uint16_t i;
+            for (i = 0; i < skip_size; ++i) {
+                (void)read_dic_byte();
+            }
+        }
+
+        skip_low = read_dic_byte();
+        skip_high = read_dic_byte();
+        skip_size = (uint16_t)(mkword(skip_high, skip_low) & 0x7FFFU);
+
+        if ((skip_high & 0x80U) != 0U) {
+            break;
+        }
+    }
+
+    return false;
+}
+static void add_candidates(uint16_t okurigana) {
+    uint8_t num_candidates = read_dic_byte();
+
+    {
+        uint8_t i;
+        for (i = 0; i < num_candidates; ++i) {
+            uint8_t candidate_length;
+
+            if (candidate_count >= MAX_CANDIDATES) {
+                break;
+            }
+
+            if (candidate_buffer_pos >= CANDIDATE_BUFFER_SIZE - 1) {
+                break;
+            }
+
+            candidate_offsets[candidate_count] = candidate_buffer_pos;
+            candidate_length = read_dic_string(&candidates_buffer[candidate_buffer_pos]);
+            candidate_buffer_pos = (uint8_t)(candidate_buffer_pos + candidate_length + 1);
+
+            if (okurigana != 0) {
+                if (candidate_buffer_pos >= CANDIDATE_BUFFER_SIZE - 2) {
+                    candidates_buffer[CANDIDATE_BUFFER_SIZE - 1] = 0;
+                    break;
+                }
+                --candidate_buffer_pos;
+                candidates_buffer[candidate_buffer_pos++] = msb16(okurigana);
+                candidates_buffer[candidate_buffer_pos++] = lsb16(okurigana);
+                candidates_buffer[candidate_buffer_pos++] = 0;
+            }
+
+            ++candidate_count;
+        }
+    }
+}
+static bool start_conversion(void) {
+    bool found = false;
+    bool verb_found = false;
+    bool noun_found = false;
+    uint8_t magic0;
+    uint8_t magic1;
+    uint8_t magic2;
+
+    if (hiragana_pos == 0) {
+        return false;
+    }
+
+    conversion_key_length = hiragana_pos;
+    if (conversion_key_length > sizeof(conversion_key_buffer)) {
+        conversion_key_length = sizeof(conversion_key_buffer);
+    }
+    memcpy(conversion_key_buffer, hiragana_buffer, conversion_key_length);
+
+    current_bank = IME_DICTIONARY_START_BANK;
+    current_offset = 0;
+    magic0 = read_rom_byte(IME_DICTIONARY_START_BANK, 0);
+    magic1 = read_rom_byte(IME_DICTIONARY_START_BANK, 1);
+    magic2 = read_rom_byte(IME_DICTIONARY_START_BANK, 2);
+
+    if (magic0 != 'D' || magic1 != 'I' || magic2 != 'C') {
+        return false;
+    }
+
+
+    candidate_buffer_pos = 0;
+    candidate_count = 0;
+    current_candidate = 0;
+    candidates_buffer[0] = 0;
+    verb_candidate_count = 0;
+    match_candidate_count = 0;
+    is_verb_first = false;
+
+    found = search_verb_entries(conversion_key_buffer, conversion_key_length);
+    verb_found = found;
+
+    if (verb_found) {
+        verb_match_length = match_length;
+        verb_match_bank = match_bank;
+        verb_match_offset = match_offset;
+        verb_match_okurigana = match_okurigana;
+    }
+
+    noun_found = search_noun_entries(conversion_key_buffer, conversion_key_length);
+
+    if (noun_found && verb_found) {
+        is_verb_first = verb_match_length > match_length;
+        if (is_verb_first) {
+            current_bank = verb_match_bank;
+            current_offset = verb_match_offset;
+            add_candidates(verb_match_okurigana);
+            verb_candidate_count = candidate_count;
+
+            current_bank = match_bank;
+            current_offset = match_offset;
+            add_candidates(0);
+            match_candidate_count = candidate_count - verb_candidate_count;
+        } else {
+            current_bank = match_bank;
+            current_offset = match_offset;
+            add_candidates(0);
+            match_candidate_count = candidate_count;
+
+            current_bank = verb_match_bank;
+            current_offset = verb_match_offset;
+            add_candidates(verb_match_okurigana);
+            verb_candidate_count = (uint8_t)(candidate_count - match_candidate_count);
+        }
+    } else if (noun_found) {
+        current_bank = match_bank;
+        current_offset = match_offset;
+        add_candidates(0);
+        match_candidate_count = candidate_count;
+    } else if (verb_found) {
+        is_verb_first = true;
+        current_bank = verb_match_bank;
+        current_offset = verb_match_offset;
+        add_candidates(verb_match_okurigana);
+        verb_candidate_count = candidate_count;
+    }
+
+    if (noun_found || verb_found) {
+        ime_conversion_state = IME_STATE_CONVERTING;
+        current_candidate = 0;
+        return candidate_count > 0;
+    }
+
+    return false;
+}
+static void next_candidate(void) {
+    if (ime_conversion_state == IME_STATE_CONVERTING && candidate_count > 0) {
+        ++current_candidate;
+        if (current_candidate >= candidate_count) {
+            current_candidate = 0;
+        }
+    }
+}
+
+static void prev_candidate(void) {
+    if (ime_conversion_state == IME_STATE_CONVERTING && candidate_count > 0) {
+        if (current_candidate == 0) {
+            current_candidate = (uint8_t)(candidate_count - 1);
+        } else {
+            --current_candidate;
+        }
+    }
+}
+
+static uint8_t* get_current_candidate(void) {
+    if (ime_conversion_state == IME_STATE_CONVERTING && candidate_count > 0 &&
+        current_candidate < candidate_count) {
+        return &candidates_buffer[candidate_offsets[current_candidate]];
+    }
+    return NULL;
+}
+static void confirm_conversion(void) {
+    if (ime_conversion_state == IME_STATE_CONVERTING) {
+        uint8_t* candidate_str = get_current_candidate();
+        if (candidate_str != NULL) {
+            uint8_t i;
+            uint8_t entry_length;
+            uint8_t remaining;
+
+            ime_output_length = 0;
+            i = 0;
+            while (candidate_str[i] != 0 && ime_output_length < sizeof(ime_output_buffer)) {
+                ime_output_buffer[ime_output_length++] = candidate_str[i++];
+            }
+            if (ime_output_length < sizeof(ime_output_buffer)) {
+                ime_output_buffer[ime_output_length] = 0;
+            }
+
+            entry_length = 0;
+            if (is_verb_first) {
+                if (current_candidate < verb_candidate_count) {
+                    entry_length = (uint8_t)(verb_match_length + 1);
+                } else {
+                    entry_length = match_length;
+                }
+            } else {
+                if (current_candidate < match_candidate_count) {
+                    entry_length = match_length;
+                } else {
+                    entry_length = (uint8_t)(verb_match_length + 1);
+                }
+            }
+
+            if (entry_length > hiragana_pos) {
+                entry_length = hiragana_pos;
+            }
+
+            if (entry_length > 0) {
+                remaining = (uint8_t)(hiragana_pos - entry_length);
+                memmove(hiragana_buffer, &hiragana_buffer[entry_length], remaining);
+                hiragana_pos = remaining;
+                if (hiragana_pos < HIRAGANA_BUFFER_SIZE) {
+                    memset(&hiragana_buffer[hiragana_pos], 0, HIRAGANA_BUFFER_SIZE - hiragana_pos);
+                }
+            }
+
+            clear_ime_input_area();
+            ime_has_output = true;
+        }
+    }
+
+    cancel_conversion();
+}
+static void cancel_conversion(void) {
+    ime_conversion_state = IME_STATE_INPUT;
+    candidate_count = 0;
+    current_candidate = 0;
+    candidate_buffer_pos = 0;
+    conversion_key_length = 0;
+    verb_candidate_count = 0;
+    match_candidate_count = 0;
+    clear_conversion_key_buffer();
+
+    prev_display_length = 0;
+    prev_display_chars = 0;
+    prev_romaji_pos = 0;
+
+    clear_ime_input_area();
+    update_ime_display();
+
+    jtxt_bwindow_disable();
+    jtxt_bcolor(1, 0);
+    jtxt_blocate(0, 23);
+    jtxt_bwindow_enable();
+}
+#include "jtxt.h"

--- a/c/src/ime_test.c
+++ b/c/src/ime_test.c
@@ -1,0 +1,145 @@
+#include <c64.h>
+#include <cbm.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "jtxt.h"
+#include "ime.h"
+
+#define POKE(addr, val) (*(volatile uint8_t*)(addr) = (uint8_t)(val))
+#define SCREEN_WIDTH 40
+
+#define INDICATOR_BITMAP_ADDR (0x6000u + (39u * 8u))
+#define INDICATOR_COLOR_ADDR  (0x5C00u + 39u)
+
+static void show_title(void);
+static void simple_input_test(void);
+static void update_indicator(uint8_t frame_counter);
+static void cleanup(void);
+
+int main(void) {
+    ime_init();
+    jtxt_init(JTXT_BITMAP_MODE);
+
+    show_title();
+    jtxt_bwindow(1, 23);
+
+    simple_input_test();
+    cleanup();
+
+    return 0;
+}
+
+static void show_title(void) {
+    jtxt_bcolor(1, 0); // white on black
+    jtxt_blocate(0, 0);
+    jtxt_bputs("IME TEST v1.0");
+
+    // Fill remaining cells on the first row with spaces
+    uint8_t cursor = jtxt_state.cursor_x;
+    for (; cursor < SCREEN_WIDTH; ++cursor) {
+        jtxt_bputc(' ');
+    }
+}
+
+static void simple_input_test(void) {
+    bool exit_requested = false;
+    uint8_t frame_counter = 0;
+
+    jtxt_bwindow(1, 23);
+    jtxt_bcolor(1, 6); // white on blue (BASIC style)
+    jtxt_bcls();
+
+    POKE(INDICATOR_COLOR_ADDR, 0x02); // red foreground indicator
+
+    while (!exit_requested) {
+        uint8_t event = ime_process();
+
+        switch (event) {
+            case IME_EVENT_CONFIRMED: {
+                const uint8_t* text = ime_get_result_text();
+                uint8_t length = ime_get_result_length();
+                if (text != NULL && length > 0) {
+                    for (uint8_t i = 0; i < length; ++i) {
+                        jtxt_bputc(text[i]);
+                    }
+                }
+                ime_clear_output();
+                break;
+            }
+            case IME_EVENT_CANCELLED:
+                // No action required
+                break;
+            case IME_EVENT_DEACTIVATED: {
+                uint8_t saved_x = jtxt_state.cursor_x;
+                uint8_t saved_y = jtxt_state.cursor_y;
+
+                jtxt_bwindow_disable();
+                jtxt_blocate(0, 24);
+                for (uint8_t col = 0; col < SCREEN_WIDTH; ++col) {
+                    jtxt_bputc(' ');
+                }
+                jtxt_bwindow(1, 23);
+                jtxt_blocate(saved_x, saved_y);
+                break;
+            }
+            case IME_EVENT_MODE_CHANGED:
+                // Status row handled inside IME
+                break;
+            case IME_EVENT_KEY_PASSTHROUGH: {
+                uint8_t passthrough_key = ime_get_passthrough_key();
+                if (passthrough_key == 20) { // Backspace/Delete
+                    if (jtxt_state.cursor_x > 0) {
+                        uint8_t saved_x = (uint8_t)(jtxt_state.cursor_x - 1);
+                        uint8_t saved_y = jtxt_state.cursor_y;
+                        jtxt_blocate(saved_x, saved_y);
+                        jtxt_bputc(' ');
+                        jtxt_blocate(saved_x, saved_y);
+                    }
+                } else if (passthrough_key == 13) { // Return
+                    jtxt_bnewline();
+                }
+                break;
+            }
+            case IME_EVENT_NONE: {
+                // IMEが非アクティブ時のみメインループでキー処理
+                if (!ime_is_active()) {
+                    uint8_t key = (uint8_t)cbm_k_getin();
+                    if (key != 0) {
+                        if (key == 27) { // ESC
+                            exit_requested = true;
+                        } else if (key == 8 || key == 20) {
+                            jtxt_bputc(8);
+                        } else if (key == 13) {
+                            jtxt_bputc(13);
+                        } else if (key >= 32 && key <= 126) {
+                            jtxt_bputc(key);
+                        }
+                    }
+                }
+                break;
+            }
+            default:
+                break;
+        }
+
+        frame_counter++;
+        update_indicator(frame_counter);
+    }
+}
+
+static void update_indicator(uint8_t frame_counter) {
+    static const uint8_t patterns[4] = { 0xFF, 0xAA, 0x00, 0x55 };
+    uint8_t pattern = patterns[(frame_counter >> 3) & 0x03];
+
+    for (uint8_t i = 0; i < 8; ++i) {
+        POKE(INDICATOR_BITMAP_ADDR + i, pattern);
+    }
+}
+
+static void cleanup(void) {
+    if (ime_is_active()) {
+        ime_toggle_mode();
+    }
+    jtxt_set_mode(JTXT_TEXT_MODE);
+}

--- a/c/src/jtxt.c
+++ b/c/src/jtxt.c
@@ -1,0 +1,230 @@
+#include "jtxt.h"
+#include <string.h>
+#include <c64.h>
+
+// Global library state
+jtxt_state_t jtxt_state = {
+    .chr_start = 128,
+    .chr_count = 64,
+    .current_index = 128,
+    .screen_pos = JTXT_SCREEN_RAM,
+    .color_pos = JTXT_COLOR_RAM,
+    .current_color = 1,
+    .sjis_first_byte = 0,
+    .display_mode = JTXT_TEXT_MODE,
+    .cursor_x = 0,
+    .cursor_y = 0,
+    .bitmap_color = (1 << 4) | 0,
+    .bitmap_top_row = 0,
+    .bitmap_bottom_row = 24,
+    .bitmap_window_enabled = false
+};
+
+// ROM access management
+static uint8_t saved_01_register = 0;
+
+// Internal macros for memory access
+#define POKE(addr, val) (*(volatile uint8_t*)(addr) = (val))
+#define PEEK(addr) (*(volatile uint8_t*)(addr))
+#define POKEW(addr, val) (*(volatile uint16_t*)(addr) = (val))
+#define PEEKW(addr) (*(volatile uint16_t*)(addr))
+
+void jtxt_init(uint8_t mode) {
+    // Set display mode
+    jtxt_set_mode(mode);
+
+    // Set MagicDesk to bank 0
+    POKE(JTXT_BANK_REG, 0);
+
+    // Disable interrupts
+    POKE(0xDC0E, PEEK(0xDC0E) & 0xFE);
+
+    // Memory map: make character ROM visible
+    POKE(0x01, 0x33);
+
+    // Copy charset to RAM in text mode only
+    if (jtxt_state.display_mode == JTXT_TEXT_MODE) {
+        jtxt_copy_charset_to_ram();
+    }
+
+    // Restore memory map
+    POKE(0x01, 0x37);
+
+    // Re-enable interrupts
+    POKE(0xDC0E, PEEK(0xDC0E) | 0x01);
+
+    // Switch VIC to RAM charset in text mode
+    if (jtxt_state.display_mode == JTXT_TEXT_MODE) {
+        POKE(0xD018, (PEEK(0xD018) & 0xF0) | 0x0C);
+    }
+}
+
+void jtxt_cleanup(void) {
+    // Return to text mode if in bitmap mode
+    if (jtxt_state.display_mode == JTXT_BITMAP_MODE) {
+        jtxt_set_mode(JTXT_TEXT_MODE);
+    }
+
+    // Reset VIC bank to 0
+    POKE(0xDD00, (PEEK(0xDD00) & 0xFC) | 0x03);
+
+    // Reset VIC registers
+    POKE(0xD018, (PEEK(0xD018) & 0x0F) | 0x10);
+
+    // Reset MagicDesk to bank 0
+    POKE(JTXT_BANK_REG, 0);
+}
+
+void jtxt_set_mode(uint8_t mode) {
+    jtxt_state.display_mode = mode;
+
+    if (mode == JTXT_BITMAP_MODE) {
+        // Clear bitmap screen
+        jtxt_bcls();
+
+        // Set VIC bank 1 (0x4000-0x7FFF)
+        POKE(0xDD00, (PEEK(0xDD00) & 0xFC) | 0x02);
+
+        // Enable bitmap mode
+        POKE(0xD011, PEEK(0xD011) | 0x20);
+
+        // Set bitmap at 0x6000, screen at 0x5C00
+        POKE(0xD018, 0x79);
+    } else {
+        // Disable bitmap mode
+        POKE(0xD011, PEEK(0xD011) & 0xDF);
+
+        // Reset to VIC bank 0
+        POKE(0xDD00, (PEEK(0xDD00) & 0xFC) | 0x03);
+
+        // Set character RAM at 0x3000
+        POKE(0xD018, (PEEK(0xD018) & 0xF0) | 0x0C);
+    }
+}
+
+void jtxt_set_range(uint8_t start_char, uint8_t char_count) {
+    jtxt_state.chr_start = start_char;
+    jtxt_state.chr_count = char_count;
+    jtxt_state.current_index = start_char;
+    jtxt_state.screen_pos = JTXT_SCREEN_RAM;
+    jtxt_state.color_pos = JTXT_COLOR_RAM;
+}
+
+void jtxt_cls(void) {
+    // Clear screen with spaces
+    memset((void*)JTXT_SCREEN_RAM, 32, 1000);
+
+    // Reset state
+    jtxt_state.current_index = jtxt_state.chr_start;
+    jtxt_locate(0, 0);
+    jtxt_state.sjis_first_byte = 0;
+}
+
+void jtxt_locate(uint8_t x, uint8_t y) {
+    jtxt_state.screen_pos = JTXT_SCREEN_RAM + (uint16_t)y * JTXT_CHAR_WIDTH + x;
+    jtxt_state.color_pos = jtxt_state.screen_pos + (JTXT_COLOR_RAM - JTXT_SCREEN_RAM);
+}
+
+void jtxt_set_color(uint8_t color) {
+    jtxt_state.current_color = color & 0x0F;
+}
+
+void jtxt_set_bgcolor(uint8_t bgcolor, uint8_t bordercolor) {
+    POKE(0xD021, bgcolor & 0x0F);
+    POKE(0xD020, bordercolor & 0x0F);
+}
+
+// Internal function to output a character (handles actual drawing)
+static void jtxt_putc_internal(uint16_t char_code) {
+    // Range check
+    if (jtxt_state.current_index >= jtxt_state.chr_start + jtxt_state.chr_count) {
+        return; // Overflow
+    }
+
+    // Define character
+    jtxt_define_char(jtxt_state.current_index, char_code);
+
+    // Display on screen
+    POKE(jtxt_state.screen_pos, jtxt_state.current_index);
+    POKE(jtxt_state.color_pos, jtxt_state.current_color);
+
+    // Update position
+    jtxt_state.current_index++;
+    if (jtxt_state.screen_pos < JTXT_SCREEN_RAM + 999) {
+        jtxt_state.screen_pos++;
+        jtxt_state.color_pos++;
+    }
+}
+
+void jtxt_putc(uint8_t char_code) {
+    // Handle Shift-JIS second byte
+    if (jtxt_state.sjis_first_byte != 0) {
+        if ((char_code >= 0x40 && char_code <= 0x7E) ||
+            (char_code >= 0x80 && char_code <= 0xFC)) {
+            // Valid Shift-JIS character
+            uint16_t sjis_code = ((uint16_t)jtxt_state.sjis_first_byte << 8) | char_code;
+            jtxt_putc_internal(sjis_code);
+            jtxt_state.sjis_first_byte = 0;
+            return;
+        } else {
+            // Invalid second byte, output first byte alone
+            jtxt_putc_internal(jtxt_state.sjis_first_byte);
+            jtxt_state.sjis_first_byte = 0;
+        }
+    }
+
+    // Check for Shift-JIS first byte
+    if ((char_code >= 0x81 && char_code <= 0x9F) ||
+        (char_code >= 0xE0 && char_code <= 0xFC)) {
+        jtxt_state.sjis_first_byte = char_code;
+        return;
+    }
+
+    // Handle newline
+    if (char_code == 0x0A || char_code == 0x0D) {
+        jtxt_newline();
+        return;
+    }
+
+    // Normal single-byte character
+    if ((char_code >= 0xA1 && char_code <= 0xDF) ||
+        (char_code >= 0x20 && char_code <= 0x7E)) {
+        jtxt_putc_internal(char_code);
+    }
+}
+
+void jtxt_puts(const char* str) {
+    while (*str) {
+        jtxt_putc(*str);
+        str++;
+    }
+}
+
+void jtxt_newline(void) {
+    uint16_t pos = jtxt_state.screen_pos - JTXT_SCREEN_RAM;
+    uint8_t row = pos / 40;
+    if (row < 24) {
+        row++;
+    }
+    jtxt_state.screen_pos = JTXT_SCREEN_RAM + (uint16_t)row * 40;
+    jtxt_state.color_pos = jtxt_state.screen_pos + (JTXT_COLOR_RAM - JTXT_SCREEN_RAM);
+}
+
+bool jtxt_is_firstsjis(uint8_t char_code) {
+    return (char_code >= 0x81 && char_code <= 0x9F) ||
+           (char_code >= 0xE0 && char_code <= 0xFC);
+}
+
+// ROM access management functions
+void jtxt_rom_access_begin(void) {
+    // Save current $01 register state
+    saved_01_register = PEEK(0x01);
+
+    // Enable BASIC ROM and LO ROM (bit 0 = 1) to access MagicDesk cartridge
+    POKE(0x01, saved_01_register | 0x01);
+}
+
+void jtxt_rom_access_end(void) {
+    // Restore original $01 register state
+    POKE(0x01, saved_01_register);
+}

--- a/c/src/jtxt_bitmap.c
+++ b/c/src/jtxt_bitmap.c
@@ -1,0 +1,220 @@
+#include "jtxt.h"
+#include <string.h>
+
+#define POKE(addr, val) (*(volatile uint8_t*)(addr) = (val))
+#define PEEK(addr) (*(volatile uint8_t*)(addr))
+
+// TODO どうにかする
+const bool is_auto_scroll = false;
+
+void jtxt_bcls(void) {
+    // Clear bitmap data in specified range
+    uint16_t bitmap_addr = JTXT_BITMAP_BASE + (uint16_t)jtxt_state.bitmap_top_row * 320;
+    uint16_t screen_addr = JTXT_BITMAP_SCREEN_RAM + (uint16_t)jtxt_state.bitmap_top_row * 40;
+
+    for (uint8_t row = jtxt_state.bitmap_top_row; row <= jtxt_state.bitmap_bottom_row; row++) {
+        // Clear bitmap data (320 bytes per row)
+        memset((void*)bitmap_addr, 0, 320);
+        bitmap_addr += 320;
+
+        // Clear color information
+        memset((void*)screen_addr, jtxt_state.bitmap_color, 40);
+        screen_addr += 40;
+    }
+
+    // Reset cursor position
+    jtxt_state.cursor_x = 0;
+    jtxt_state.cursor_y = jtxt_state.bitmap_top_row;
+    jtxt_state.sjis_first_byte = 0;
+}
+
+void jtxt_blocate(uint8_t x, uint8_t y) {
+    jtxt_state.cursor_x = x;
+    jtxt_state.cursor_y = y;
+}
+
+void jtxt_bcolor(uint8_t fg, uint8_t bg) {
+    jtxt_state.bitmap_color = ((fg & 0x0F) << 4) | (bg & 0x0F);
+}
+
+void jtxt_bwindow(uint8_t top_row, uint8_t bottom_row) {
+    jtxt_state.bitmap_top_row = top_row;
+    jtxt_state.bitmap_bottom_row = bottom_row;
+}
+
+void jtxt_bwindow_enable(void) {
+    jtxt_state.bitmap_window_enabled = true;
+}
+
+void jtxt_bwindow_disable(void) {
+    jtxt_state.bitmap_window_enabled = false;
+}
+
+void jtxt_bnewline(void) {
+    jtxt_state.cursor_x = 0;
+
+    if (jtxt_state.cursor_y >= jtxt_state.bitmap_bottom_row) {
+        if (jtxt_state.bitmap_window_enabled) {
+            jtxt_bscroll_up();
+        }
+        jtxt_state.cursor_y = jtxt_state.bitmap_bottom_row;
+    } else {
+        jtxt_state.cursor_y++;
+    }
+}
+
+void jtxt_bbackspace(void) {
+    // Cancel Shift-JIS state if active
+    if (jtxt_state.sjis_first_byte != 0) {
+        jtxt_state.sjis_first_byte = 0;
+        return;
+    }
+
+    // Move cursor back
+    if (jtxt_state.cursor_x != 0) {
+        jtxt_state.cursor_x--;
+    } else {
+        if (jtxt_state.cursor_y > jtxt_state.bitmap_top_row) {
+            jtxt_state.cursor_y--;
+            jtxt_state.cursor_x = 39;
+        } else {
+            return;
+        }
+    }
+
+    // Check window bounds
+    if (jtxt_state.cursor_y < jtxt_state.bitmap_top_row ||
+        jtxt_state.cursor_y > jtxt_state.bitmap_bottom_row) {
+        return;
+    }
+
+    // Draw space character to erase
+    jtxt_draw_font_to_bitmap(32);
+}
+
+void jtxt_bscroll_up(void) {
+    uint16_t dst_bitmap = JTXT_BITMAP_BASE + (uint16_t)jtxt_state.bitmap_top_row * 320;
+    uint16_t src_bitmap = dst_bitmap + 320;
+    uint16_t dst_screen = JTXT_BITMAP_SCREEN_RAM + (uint16_t)jtxt_state.bitmap_top_row * 40;
+    uint16_t src_screen = dst_screen + 40;
+
+    // Scroll each row
+    for (uint8_t i = jtxt_state.bitmap_top_row; i < jtxt_state.bitmap_bottom_row; i++) {
+        // Copy bitmap data
+        memcpy((void*)dst_bitmap, (void*)src_bitmap, 320);
+        dst_bitmap += 320;
+        src_bitmap += 320;
+
+        // Copy color data
+        memcpy((void*)dst_screen, (void*)src_screen, 40);
+        dst_screen += 40;
+        src_screen += 40;
+    }
+
+    // Clear last row
+    memset((void*)dst_bitmap, 0, 320);
+    memset((void*)dst_screen, jtxt_state.bitmap_color, 40);
+}
+
+void jtxt_draw_font_to_bitmap(uint16_t char_code) {
+    // Set color information
+    POKE(JTXT_BITMAP_SCREEN_RAM + (uint16_t)jtxt_state.cursor_y * 40 + jtxt_state.cursor_x,
+         jtxt_state.bitmap_color);
+
+    // Calculate bitmap address
+    uint16_t bitmap_addr = JTXT_BITMAP_BASE +
+                          ((uint16_t)(jtxt_state.cursor_y / 8) * 320 * 8) +
+                          ((uint16_t)(jtxt_state.cursor_y & 7) * 320) +
+                          ((uint16_t)jtxt_state.cursor_x * 8);
+
+    // Write font data to bitmap
+    jtxt_define_font(bitmap_addr, char_code);
+}
+
+// Internal function for bitmap character output
+static void jtxt_bputc_internal(uint16_t char_code) {
+    // Check window bounds
+    if (jtxt_state.bitmap_window_enabled &&
+        (jtxt_state.cursor_y < jtxt_state.bitmap_top_row ||
+         jtxt_state.cursor_y > jtxt_state.bitmap_bottom_row)) {
+        return;
+    }
+
+    // Draw character to bitmap
+    jtxt_draw_font_to_bitmap(char_code);
+
+    // Move to next position
+    jtxt_state.cursor_x++;
+    if (is_auto_scroll && jtxt_state.cursor_x >= 40) {
+        jtxt_bnewline();
+    }
+}
+
+void jtxt_bputc(uint8_t char_code) {
+    // Handle Shift-JIS second byte
+    if (jtxt_state.sjis_first_byte != 0) {
+        if ((char_code >= 0x40 && char_code <= 0x7E) ||
+            (char_code >= 0x80 && char_code <= 0xFC)) {
+            // Valid Shift-JIS character
+            uint16_t sjis_code = ((uint16_t)jtxt_state.sjis_first_byte << 8) | char_code;
+            jtxt_bputc_internal(sjis_code);
+            jtxt_state.sjis_first_byte = 0;
+            return;
+        } else {
+            // Invalid second byte
+            jtxt_bputc_internal(jtxt_state.sjis_first_byte);
+            jtxt_state.sjis_first_byte = 0;
+        }
+    }
+
+    // Check for Shift-JIS first byte
+    if ((char_code >= 0x81 && char_code <= 0x9F) ||
+        (char_code >= 0xE0 && char_code <= 0xFC)) {
+        jtxt_state.sjis_first_byte = char_code;
+        return;
+    }
+
+    // Handle backspace
+    if (char_code == 0x08) {
+        jtxt_bbackspace();
+        return;
+    }
+
+    // Handle newline
+    if (char_code == 0x0D) {
+        jtxt_bnewline();
+        return;
+    }
+
+    // Normal single-byte character
+    if ((char_code >= 0xA1 && char_code <= 0xDF) ||
+        (char_code >= 0x20 && char_code <= 0x7E)) {
+        jtxt_bputc_internal(char_code);
+    }
+}
+
+void jtxt_bputs(const char* str) {
+    while (*str) {
+        jtxt_bputc(*str);
+        str++;
+    }
+}
+
+void jtxt_bput_hex2(uint8_t value) {
+    uint8_t hi = value >> 4;
+    uint8_t lo = value & 0x0F;
+
+    jtxt_bputc((hi < 10) ? ('0' + hi) : ('A' + hi - 10));
+    jtxt_bputc((lo < 10) ? ('0' + lo) : ('A' + lo - 10));
+}
+
+void jtxt_bput_dec2(uint8_t value) {
+    jtxt_bputc('0' + (value / 10));
+    jtxt_bputc('0' + (value % 10));
+}
+
+void jtxt_bput_dec3(uint8_t value) {
+    jtxt_bputc('0' + (value / 100));
+    jtxt_bputc('0' + ((value / 10) % 10));
+    jtxt_bputc('0' + (value % 10));
+}

--- a/c/src/jtxt_charset.c
+++ b/c/src/jtxt_charset.c
@@ -1,0 +1,124 @@
+#include "jtxt.h"
+#include <string.h>
+
+#define POKE(addr, val) (*(volatile uint8_t*)(addr) = (val))
+#define PEEK(addr) (*(volatile uint8_t*)(addr))
+
+void jtxt_copy_charset_to_ram(void) {
+    // Copy 2KB of character ROM to RAM
+    memcpy((void*)JTXT_CHARSET_RAM, (void*)JTXT_CHARSET_ROM, 2048);
+}
+
+uint16_t jtxt_sjis_to_offset(uint16_t sjis_code) {
+    uint8_t ch = (sjis_code >> 8) & 0xFF;
+    uint8_t ch2 = sjis_code & 0xFF;
+
+    // Shift-JIS to Ku/Ten conversion
+    if (ch <= 0x9F) {
+        ch = ((uint16_t)ch << 1) - 0x102;
+    } else {
+        ch = ((uint16_t)ch << 1) - 0x182;
+    }
+
+    if (ch2 >= 0x9F) {
+        ch++;
+    }
+
+    if (ch2 < 0x7F) {
+        ch2 -= 0x40;
+    } else if (ch2 < 0x9F) {
+        ch2 -= 0x41;
+    } else {
+        ch2 -= 0x9F;
+    }
+
+    return ((uint16_t)ch * 94 + ch2) * 8 + JTXT_JISX0208_OFFSET;
+}
+
+void jtxt_define_jisx0201(uint8_t jisx0201_code) {
+    // Calculate source address in ROM
+    uint16_t src_addr = JTXT_ROM_BASE + ((uint16_t)jisx0201_code * 8);
+
+    // Begin ROM access with $01 register backup
+    jtxt_rom_access_begin();
+
+    // Switch to bank 1 for JIS X 0201 font
+    POKE(JTXT_BANK_REG, 1);
+
+    // Copy 8 bytes of font data
+    uint16_t dst_addr = jtxt_state.screen_pos;
+
+    if(jisx0201_code == 0x20) {
+        *(volatile uint32_t*)(dst_addr) = 0;
+        dst_addr += 4;
+        *(volatile uint32_t*)(dst_addr)   = 0;
+    } else {
+        *(volatile uint8_t*)(dst_addr++) = *(volatile uint8_t*)(src_addr++);
+        *(volatile uint8_t*)(dst_addr++) = *(volatile uint8_t*)(src_addr++);
+        *(volatile uint8_t*)(dst_addr++) = *(volatile uint8_t*)(src_addr++);
+        *(volatile uint8_t*)(dst_addr++) = *(volatile uint8_t*)(src_addr++);
+        *(volatile uint8_t*)(dst_addr++) = *(volatile uint8_t*)(src_addr++);
+        *(volatile uint8_t*)(dst_addr++) = *(volatile uint8_t*)(src_addr++);
+        *(volatile uint8_t*)(dst_addr++) = *(volatile uint8_t*)(src_addr++);
+        *(volatile uint8_t*)(dst_addr) = *(volatile uint8_t*)(src_addr);
+    }
+
+    // Switch back to bank 0
+    POKE(JTXT_BANK_REG, 0);
+
+    // End ROM access with $01 register restore
+    jtxt_rom_access_end();
+}
+
+void jtxt_define_kanji(uint16_t sjis_code) {
+    uint16_t kanji_offset = jtxt_sjis_to_offset(sjis_code);
+    uint8_t bank = (kanji_offset / 8192) + 1;
+    uint16_t in_bank_offset = kanji_offset % 8192;
+
+    // Begin ROM access with $01 register backup
+    jtxt_rom_access_begin();
+
+    // Switch to appropriate bank
+    POKE(JTXT_BANK_REG, bank);
+
+    uint16_t rom_addr = JTXT_ROM_BASE + in_bank_offset;
+
+    // Copy 8 bytes of font data
+    uint16_t dst_addr = jtxt_state.screen_pos;
+
+    *(volatile uint8_t*)(dst_addr++) = *(volatile uint8_t*)(rom_addr++);
+    *(volatile uint8_t*)(dst_addr++) = *(volatile uint8_t*)(rom_addr++);
+    *(volatile uint8_t*)(dst_addr++) = *(volatile uint8_t*)(rom_addr++);
+    *(volatile uint8_t*)(dst_addr++) = *(volatile uint8_t*)(rom_addr++);
+    *(volatile uint8_t*)(dst_addr++) = *(volatile uint8_t*)(rom_addr++);
+    *(volatile uint8_t*)(dst_addr++) = *(volatile uint8_t*)(rom_addr++);
+    *(volatile uint8_t*)(dst_addr++) = *(volatile uint8_t*)(rom_addr++);
+    *(volatile uint8_t*)(dst_addr) = *(volatile uint8_t*)(rom_addr);
+
+    // Switch back to bank 0
+    POKE(JTXT_BANK_REG, 0);
+
+    // End ROM access with $01 register restore
+    jtxt_rom_access_end();
+}
+
+void jtxt_define_font(uint16_t dest_addr, uint16_t code) {
+    // Save destination address temporarily
+    uint16_t saved_pos = jtxt_state.screen_pos;
+    jtxt_state.screen_pos = dest_addr;
+
+    if ((code & 0xFF00) == 0) {
+        // Single-byte character (ASCII, half-width kana)
+        jtxt_define_jisx0201(code & 0xFF);
+    } else {
+        // Double-byte character (kanji)
+        jtxt_define_kanji(code);
+    }
+
+    // Restore original position
+    jtxt_state.screen_pos = saved_pos;
+}
+
+void jtxt_define_char(uint8_t char_code, uint16_t code) {
+    jtxt_define_font(JTXT_CHARSET_RAM + (uint16_t)char_code * 8, code);
+}

--- a/c/src/jtxt_resource.c
+++ b/c/src/jtxt_resource.c
@@ -1,0 +1,90 @@
+#include "jtxt.h"
+#include <string.h>
+
+#define POKE(addr, val) (*(volatile uint8_t*)(addr) = (val))
+#define PEEK(addr) (*(volatile uint8_t*)(addr))
+
+bool jtxt_load_string_resource(uint8_t resource_number) {
+    // Begin ROM access with $01 register backup
+    jtxt_rom_access_begin();
+
+    // Switch to string resource bank
+    POKE(JTXT_BANK_REG, JTXT_STRING_RESOURCE_BANK);
+
+    // Get number of strings (little-endian 4 bytes, but we only need the low word)
+    uint16_t num_strings = PEEK(JTXT_STRING_RESOURCE_BASE) |
+                          ((uint16_t)PEEK(JTXT_STRING_RESOURCE_BASE + 1) << 8);
+
+    // Range check
+    if (resource_number >= (num_strings & 0xFF)) {
+        POKE(JTXT_BANK_REG, 0);
+        jtxt_rom_access_end();
+        return false;
+    }
+
+    // Read offset table entry (4 bytes per entry)
+    uint16_t offset_table_addr = JTXT_STRING_RESOURCE_BASE + 4 + (uint16_t)resource_number * 4;
+    uint8_t target_bank = PEEK(offset_table_addr);
+    // uint8_t reserved = PEEK(offset_table_addr + 1); // Not used
+    uint16_t string_offset = PEEK(offset_table_addr + 2) |
+                            ((uint16_t)PEEK(offset_table_addr + 3) << 8);
+
+    // Check for undefined string
+    if (target_bank == 0 && string_offset == 0) {
+        POKE(JTXT_BANK_REG, 0);
+        jtxt_rom_access_end();
+        return false;
+    }
+
+    // Switch to bank containing the string
+    POKE(JTXT_BANK_REG, target_bank);
+
+    // Copy string to RAM buffer
+    uint16_t string_addr = JTXT_ROM_BASE + string_offset;
+    uint8_t buffer_pos = 0;
+    uint8_t current_bank = target_bank;
+    uint16_t current_addr = string_addr;
+
+    while (buffer_pos < JTXT_STRING_BUFFER_SIZE) {
+        // Check for 8KB boundary crossing
+        if (current_addr > 0x9FFF) {
+            current_bank++;
+            current_addr = JTXT_ROM_BASE;
+            POKE(JTXT_BANK_REG, current_bank);
+        }
+
+        uint8_t char_data = PEEK(current_addr);
+        POKE(JTXT_STRING_BUFFER + buffer_pos, char_data);
+
+        if (char_data == 0) {
+            break; // NULL terminator
+        }
+
+        buffer_pos++;
+        current_addr++;
+    }
+
+    // Ensure NULL termination
+    if (buffer_pos >= JTXT_STRING_BUFFER_SIZE) {
+        POKE(JTXT_STRING_BUFFER + JTXT_STRING_BUFFER_SIZE, 0);
+    }
+
+    // Return to bank 0
+    POKE(JTXT_BANK_REG, 0);
+
+    // End ROM access with $01 register restore
+    jtxt_rom_access_end();
+    return true;
+}
+
+void jtxt_putr(uint8_t resource_number) {
+    if (jtxt_load_string_resource(resource_number)) {
+        jtxt_puts((const char*)JTXT_STRING_BUFFER);
+    }
+}
+
+void jtxt_bputr(uint8_t resource_number) {
+    if (jtxt_load_string_resource(resource_number)) {
+        jtxt_bputs((const char*)JTXT_STRING_BUFFER);
+    }
+}

--- a/c/src/jtxt_text.c
+++ b/c/src/jtxt_text.c
@@ -1,0 +1,4 @@
+#include "jtxt.h"
+
+// This file can be used for additional text mode specific functions if needed
+// Currently most text mode functions are in jtxt.c

--- a/c/src/qe/Makefile
+++ b/c/src/qe/Makefile
@@ -1,0 +1,138 @@
+# QE Text Editor for C64 - llvm-mos build
+# Based on qe by David Given
+
+# Compiler settings
+CC = mos-c64-clang
+AS = mos-c64-clang
+
+COMMON_CFLAGS = -Oz -Wall -flto -std=c99 -I../../include \
+    -flto=full -ffunction-sections -fdata-sections \
+    -fshort-enums -fmerge-all-constants -fno-stack-protector -fverbose-asm
+CFLAGS ?=
+
+ENABLE_IME := 1
+
+ifeq ($(QE_ENABLE_IME),1)
+ENABLE_IME := 1
+endif
+
+ifneq ($(findstring -DQE_ENABLE_IME,$(CFLAGS)),)
+ENABLE_IME := 1
+endif
+# Enable file I/O using KERNAL routines
+CFLAGS += -DENABLE_FILE_IO
+LDFLAGS = -Wl,--gc-sections -Wl,--Map=$(BUILD_DIR)/$(TARGET).map -Wl,--print-memory-usage,--icf=safe -Wl,-s
+
+# Directories
+SRC_DIR = .
+LIB_DIR = lib
+BUILD_DIR = ../../build
+TARGET = qe
+
+# Source files
+C_SOURCES = qe.c $(LIB_DIR)/screen.c
+ASM_SOURCES = $(LIB_DIR)/kernal_getin.s
+TEST_SOURCES = fio_test.c
+JTXT_SOURCES = ../../src/jtxt.c ../../src/jtxt_charset.c ../../src/jtxt_bitmap.c ../../src/jtxt_resource.c
+
+ifeq ($(ENABLE_IME),1)
+IME_SOURCES = ../../src/ime.c
+endif
+
+# Object files
+C_OBJECTS = $(C_SOURCES:.c=.o)
+ASM_OBJECTS = $(ASM_SOURCES:.s=.o)
+JTXT_OBJECTS = $(JTXT_SOURCES:.c=.o)
+IME_OBJECTS = $(IME_SOURCES:.c=.o)
+OBJECTS = $(C_OBJECTS) $(ASM_OBJECTS) $(JTXT_OBJECTS) $(IME_OBJECTS)
+
+# Main targets
+.PHONY: all clean test install qe-run
+
+all: $(BUILD_DIR)/$(TARGET).prg
+
+# Build main editor
+
+ifeq ($(ENABLE_IME),1)
+COMMON_CFLAGS += -DQE_ENABLE_IME
+endif
+
+$(BUILD_DIR)/$(TARGET).prg: $(OBJECTS) | $(BUILD_DIR)
+	@echo "Linking QE editor..."
+	$(CC) $(COMMON_CFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJECTS)
+	@echo "✓ QE editor built: $@"
+
+# Build test program
+
+$(BUILD_DIR)/qe_fio_test.prg: fio_test.o $(LIB_DIR)/screen.o $(ASM_OBJECTS) | $(BUILD_DIR)
+	@echo "Linking QE file I/O test..."
+	$(CC) $(COMMON_CFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $^
+	@echo "✓ QE test built: $@"
+
+# Compile C sources
+
+%.o: %.c
+	@echo "Compiling $<..."
+	$(CC) $(COMMON_CFLAGS) $(CFLAGS) -c $< -o $@
+
+# Compile assembly sources
+%.o: %.s
+	@echo "Assembling $<..."
+	$(AS) -c $< -o $@
+
+# Create build directory
+$(BUILD_DIR):
+	@mkdir -p $(BUILD_DIR)
+
+# Test target
+test: $(BUILD_DIR)/qe_fio_test.prg
+	@echo "QE test program built"
+
+# Install target (copy to main project)
+install: $(BUILD_DIR)/$(TARGET).prg
+	@echo "QE editor installed to build directory"
+
+# Run target
+run: $(BUILD_DIR)/$(TARGET).prg
+	@echo "=== Running QE Editor ==="
+	@if [ -f "../../../crt/c64jpkanji.crt" ]; then \
+		echo "Starting with Japanese kanji cartridge..."; \
+		x64sc -cartcrt "../../../crt/c64jpkanji.crt" -autostart "$(BUILD_DIR)/$(TARGET).prg"; \
+	else \
+		echo "Starting without cartridge..."; \
+		x64sc -autostart "$(BUILD_DIR)/$(TARGET).prg"; \
+	fi
+
+# Run test
+run-test: $(BUILD_DIR)/qe_fio_test.prg
+	@echo "=== Running QE Test ==="
+	@x64sc -autostart "$(BUILD_DIR)/qe_fio_test.prg"
+
+# QE run alias
+qe-run: run
+
+# Clean
+clean:
+	@echo "Cleaning QE build files..."
+	@rm -f $(OBJECTS)
+	@rm -f $(LIB_DIR)/*.o
+	@rm -f $(BUILD_DIR)/$(TARGET).prg
+	@rm -f $(BUILD_DIR)/qe_fio_test.prg
+	@echo "QE cleanup completed"
+
+# Debug info
+debug:
+	@echo "=== QE Build Configuration ==="
+	@echo "CC: $(CC)"
+	@echo "COMMON_CFLAGS: $(COMMON_CFLAGS)"
+	@echo "CFLAGS: $(CFLAGS)"
+	@echo "LDFLAGS: $(LDFLAGS)"
+	@echo "C_SOURCES: $(C_SOURCES)"
+	@echo "ASM_SOURCES: $(ASM_SOURCES)"
+	@echo "OBJECTS: $(OBJECTS)"
+	@echo "TARGET: $(BUILD_DIR)/$(TARGET).prg"
+
+# Dependencies
+qe.o: qe.c $(LIB_DIR)/screen.h
+$(LIB_DIR)/screen.o: $(LIB_DIR)/screen.c $(LIB_DIR)/screen.h
+fio_test.o: fio_test.c $(LIB_DIR)/screen.h

--- a/c/src/qe/Makefile
+++ b/c/src/qe/Makefile
@@ -31,7 +31,6 @@ TARGET = qe
 
 # Source files
 C_SOURCES = qe.c $(LIB_DIR)/screen.c
-ASM_SOURCES = $(LIB_DIR)/kernal_getin.s
 TEST_SOURCES = fio_test.c
 JTXT_SOURCES = ../../src/jtxt.c ../../src/jtxt_charset.c ../../src/jtxt_bitmap.c ../../src/jtxt_resource.c
 
@@ -41,10 +40,9 @@ endif
 
 # Object files
 C_OBJECTS = $(C_SOURCES:.c=.o)
-ASM_OBJECTS = $(ASM_SOURCES:.s=.o)
 JTXT_OBJECTS = $(JTXT_SOURCES:.c=.o)
 IME_OBJECTS = $(IME_SOURCES:.c=.o)
-OBJECTS = $(C_OBJECTS) $(ASM_OBJECTS) $(JTXT_OBJECTS) $(IME_OBJECTS)
+OBJECTS = $(C_OBJECTS) $(JTXT_OBJECTS) $(IME_OBJECTS)
 
 # Main targets
 .PHONY: all clean test install qe-run

--- a/c/src/qe/README.md
+++ b/c/src/qe/README.md
@@ -1,0 +1,195 @@
+# QE - Text Editor for Commodore 64
+
+QEは、Commodore 64用の日本語対応テキストエディタです。
+
+## 概要
+
+このエディタは、David GivenによるCP/M-65プロジェクトの[qe](https://github.com/davidgiven/cpm65/blob/master/apps/qe.c)を大幅に改造したものです。元のエディタはCP/M-65用に設計されていましたが、本バージョンではCommodore 64のネイティブ環境向けに以下の機能を追加しています：
+
+### 主な機能
+
+- **日本語表示対応**: Shift-JIS文字コードによる全角文字の表示
+- **ビットマップモード**: jtxtライブラリによる高品質な日本語表示
+- **かな漢字変換**: IMEによるローマ字入力からの日本語変換（オプション）
+- **Viライクなキーバインディング**: 効率的なテキスト編集操作
+- **ファイルI/O**: C64 KERNALルーチンによるファイルの読み書き
+
+## ビルド方法
+
+```bash
+cd /path/to/qe
+make                    # デフォルトビルド（IME有効）
+make QE_ENABLE_IME=0    # IME無効でビルド
+```
+
+### ビルドオプション
+
+- `QE_ENABLE_IME=1`: かな漢字変換機能を有効化（デフォルト）
+- `ENABLE_FILE_IO`: ファイル入出力機能を有効化（デフォルトで有効）
+
+## 実行方法
+
+```bash
+make run                # エディタを起動
+```
+
+MagicDesk形式のROMカートリッジ（日本語フォント・辞書データ）が必要です。
+カートリッジファイルは `../../../crt/c64jpkanji.crt` に配置してください。
+
+## エディタの基本概念
+
+QEは**モーダルエディタ**です。一般的なエディタ（メモ帳など）と異なり、キーボード入力の動作が「モード」によって変わります。
+
+### モードとは
+
+- **ノーマルモード**（起動時のデフォルト）: カーソル移動、削除、コマンド実行などを行うモード。文字キーを押しても文字は入力されません。
+- **インサートモード**: 文字入力を行うモード。キーを押すとその文字がテキストに挿入されます。
+- **リプレースモード**: 既存の文字を上書きするモード。
+
+この仕組みにより、キーボードのホームポジションを崩さずに素早く編集できます。例えば、ノーマルモードで`h` `j` `k` `l`キーがカーソル移動になるため、矢印キーに手を伸ばす必要がありません。
+
+### 基本的な流れ
+
+1. エディタ起動 → **ノーマルモード**
+2. `i`キーを押す → **インサートモード**に切り替わり、文字入力開始
+3. `ESC`キーを押す → **ノーマルモード**に戻る
+4. `:`キーを押してコマンド入力（例：`:w`で保存、`:q`で終了）
+
+## 基本操作
+
+### ノーマルモード
+
+| キー | 動作 |
+|------|------|
+| `i` | インサートモード開始 |
+| `A` | 行末からインサートモード開始 |
+| `o` | 下に新しい行を挿入してインサートモード |
+| `O` | 上に新しい行を挿入してインサートモード |
+| `h` `j` `k` `l` | カーソル移動（左・下・上・右） |
+| `^` `$` | 行頭・行末に移動 |
+| `G` | 指定行に移動 |
+| `x` | 1文字削除 |
+| `dd` | 行削除 |
+| `d$` | カーソル位置から行末まで削除 |
+| `J` | 次の行を連結 |
+| `R` | リプレースモード |
+| `:` | コロンコマンドモード |
+| `Ctrl+R` | 画面再描画 |
+
+### インサートモード / リプレースモード
+
+| キー | 動作 |
+|------|------|
+| `ESC` | ノーマルモードに戻る |
+| `Commodore + Space` | IME有効化（IME有効ビルドのみ） |
+| `Backspace` | 1文字削除（全角対応） |
+| 通常文字 | 文字入力 |
+
+### コロンコマンド
+
+| コマンド | 動作 |
+|----------|------|
+| `:w` | ファイル保存 |
+| `:w filename` | 指定ファイル名で保存 |
+| `:q` | 終了 |
+| `:q!` | 強制終了（未保存でも終了） |
+| `:e filename` | ファイルを開く |
+| `:e!` | 再読み込み（変更を破棄） |
+| `:n` | 新規ファイル |
+| `:n!` | 強制的に新規ファイル（変更を破棄） |
+
+## IME（かな漢字変換）
+
+IME有効ビルドでは、インサートモード中に`Commodore + Space`でIMEを有効化できます。
+
+### IME操作
+
+- **ローマ字入力**: `a`, `ka`, `kya`などで入力
+- **変換**: `Space`キーで変換候補を表示
+- **候補選択**: `Space`で次候補、`Shift+Space`で前候補
+- **確定**: `Enter`で確定
+- **キャンセル**: `ESC`でIME無効化
+- **モード切り替え**: `Ctrl+K`でひらがな/カタカナ切り替え
+
+## 技術仕様
+
+### メモリ使用
+
+- エディタバッファ: 11KB ($A000-$CBFF)
+- ビットマップ画面: $5C00-$7FFF
+- テキスト領域: 40列 × 25行
+
+### ファイルフォーマット
+
+- エンコーディング: Shift-JIS
+- 改行コード: CR ($0D)
+- 最大ファイル名長: 64文字
+
+### Shift-JIS対応
+
+全角文字（2バイト文字）は以下のように処理されます：
+
+- 第1バイト: 0x81-0x9F または 0xE0-0xFC
+- 第2バイト: 任意のバイト
+- カーソル移動、削除、置換などの操作で文字境界を自動判定
+
+## ビルド要件
+
+- **コンパイラ**: llvm-mos (mos-c64-clang)
+- **依存ライブラリ**:
+  - jtxt (日本語テキスト表示)
+  - ime (かな漢字変換、オプション)
+- **カートリッジ**: MagicDesk形式ROMカートリッジ（日本語フォント・辞書データ）
+
+## 制限事項
+
+- 最大編集可能サイズ: 約11KB
+- 長い行（40文字以上）は複数の画面行に折り返されます
+- Undo/Redo機能なし
+- 検索・置換機能なし
+
+## ライセンス
+
+このソフトウェアは、元のqeエディタ（© 2019 David Given）を大幅に改造したものです。
+
+元のqeエディタは2条項BSDライセンスの下で配布されています：
+https://github.com/davidgiven/cpm65
+
+改変部分も同じ2条項BSDライセンスの下で配布されます。
+
+### 2-Clause BSD License
+
+Copyright (c) 2019 David Given (original qe editor)
+Copyright (c) 2025 Hiroshi OGINO / H.O SOFT Inc. (Japanese language support and C64 port)
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+## クレジット
+
+- **元のqeエディタ**: David Given (https://github.com/davidgiven/cpm65)
+- **C64移植・日本語対応**: Hiroshi OGINO / H.O SOFT Inc. (https://github.com/h-o-soft/c64jp)
+- **美咲フォント**: 門真なむ氏 (https://littlelimit.net/misaki.htm)
+
+## 参考リンク
+
+- 元のqeエディタ: https://github.com/davidgiven/cpm65/blob/master/apps/qe.c
+- c64jpプロジェクト: https://github.com/h-o-soft/c64jp

--- a/c/src/qe/fio_test.c
+++ b/c/src/qe/fio_test.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+int main(void) {
+    FILE *fp = fopen("test", "r");
+    if (!fp) {
+        puts("open failed");
+    }
+    return 0;
+}

--- a/c/src/qe/lib/kernal_getin.s
+++ b/c/src/qe/lib/kernal_getin.s
@@ -1,0 +1,4 @@
+        .globl kernal_getin
+kernal_getin:
+        jsr $ffe4
+        rts

--- a/c/src/qe/lib/kernal_getin.s
+++ b/c/src/qe/lib/kernal_getin.s
@@ -1,4 +1,0 @@
-        .globl kernal_getin
-kernal_getin:
-        jsr $ffe4
-        rts

--- a/c/src/qe/lib/screen.c
+++ b/c/src/qe/lib/screen.c
@@ -1,5 +1,6 @@
 #include "screen.h"
 #include <c64.h>
+#include <cbm.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -19,8 +20,6 @@ static const uint8_t normal_bg_color = 6;  // Blue background
 static const uint8_t status_fg_color = 0;  // Black text
 static const uint8_t status_bg_color = 1;  // White background
 static bool sjis_lead_pending = false;
-
-extern uint8_t kernal_getin(void);
 
 // MagicDesk cartridge detection
 static bool check_magicdesk_cartridge(void)
@@ -207,7 +206,7 @@ static uint8_t translate_key(uint8_t c)
 uint16_t screen_getchar(uint16_t timeout_cs)
 {
     (void)timeout_cs;
-    uint8_t value = kernal_getin();
+    uint8_t value = cbm_k_getin();
     if (value == 0)
         return 0;
     uint8_t key = translate_key(value);

--- a/c/src/qe/lib/screen.c
+++ b/c/src/qe/lib/screen.c
@@ -1,0 +1,266 @@
+#include "screen.h"
+#include <c64.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdbool.h>
+#include "jtxt.h"
+
+#define SCREEN_COLS 40
+#define SCREEN_ROWS 25
+#define SCREEN_SIZE (SCREEN_COLS * SCREEN_ROWS)
+
+static uint8_t cursor_x;
+static uint8_t cursor_y;
+static uint8_t current_style;
+static const uint8_t normal_fg_color = 1;  // White text
+static const uint8_t normal_bg_color = 6;  // Blue background
+static const uint8_t status_fg_color = 0;  // Black text
+static const uint8_t status_bg_color = 1;  // White background
+static bool sjis_lead_pending = false;
+
+extern uint8_t kernal_getin(void);
+
+// MagicDesk cartridge detection
+static bool check_magicdesk_cartridge(void)
+{
+    // Try to read from MagicDesk bank register
+    volatile uint8_t* bank_reg = (volatile uint8_t*)0xDE00;
+
+    // Save original value
+    uint8_t original = *bank_reg;
+
+    // Try to switch banks and verify
+    *bank_reg = 0;
+    uint8_t test1 = *bank_reg;
+
+    *bank_reg = 1;
+    uint8_t test2 = *bank_reg;
+
+    // Restore original value
+    *bank_reg = original;
+
+    // If we can't switch banks, cartridge might not be present
+    return (test1 != test2) || (original == 0);
+}
+
+// カーソル位置の文字を反転表示（外部から呼び出し用）
+void screen_invert_cursor(uint8_t x, uint8_t y)
+{
+    if (x < SCREEN_COLS && y < SCREEN_ROWS)
+    {
+        uint16_t pos = y * SCREEN_COLS + x;
+        uint8_t* color_ram = (uint8_t*)0x5C00;
+        uint8_t color = color_ram[pos];
+        color_ram[pos] = ((color & 0x0F) << 4) | ((color & 0xF0) >> 4);
+    }
+}
+
+static void mark_cell(uint8_t x, uint8_t y, uint8_t ch)
+{
+    if (current_style == 1) {
+        jtxt_bcolor(status_fg_color, status_bg_color);
+    } else {
+        jtxt_bcolor(normal_fg_color, normal_bg_color);
+    }
+
+    jtxt_blocate(x, y);
+    jtxt_bputc(ch);
+}
+
+static uint8_t ascii_to_screen(uint8_t c)
+{
+    // jtxt handles ASCII directly, no conversion needed
+    return c;
+}
+
+static uint8_t petscii_to_ascii(uint8_t c)
+{
+    if (c >= 65 && c <= 90)
+        return (uint8_t)(c + 32); /* unshifted letters -> lowercase ASCII */
+    if (c >= 193 && c <= 218)
+        return (uint8_t)(c - 128); /* shifted letters -> uppercase ASCII */
+    if (c == 13)
+        return 13;
+    if (c == 20)
+        return 127;
+    return c;
+}
+
+uint8_t screen_init(void)
+{
+    jtxt_init(JTXT_BITMAP_MODE);
+
+    cursor_x = 0;
+    cursor_y = 0;
+    current_style = 0;
+
+    // Set default colors
+    jtxt_bcolor(normal_fg_color, normal_bg_color);
+
+    screen_clear();
+    screen_showcursor(1);
+    return 1;
+}
+
+void screen_shutdown(void)
+{
+    screen_showcursor(1);
+    jtxt_cleanup();
+}
+
+void screen_clear(void)
+{
+    jtxt_bcls();
+    cursor_x = 0;
+    cursor_y = 0;
+    sjis_lead_pending = false;
+}
+
+uint16_t _screen_getsize(void)
+{
+    return (uint16_t)(((SCREEN_ROWS - 1) << 8) | (SCREEN_COLS - 1));
+}
+
+void _screen_setcursor(uint16_t cursor)
+{
+    cursor_x = cursor & 0xff;
+    cursor_y = (cursor >> 8) & 0xff;
+    sjis_lead_pending = false;
+}
+
+uint16_t _screen_getcursor(void)
+{
+    return (uint16_t)(((uint16_t)cursor_y << 8) | cursor_x);
+}
+
+static void advance_cursor(void)
+{
+    cursor_x++;
+    if (cursor_x >= SCREEN_COLS)
+    {
+        cursor_x = 0;
+        if (cursor_y < SCREEN_ROWS - 1)
+            cursor_y++;
+    }
+}
+
+void screen_putchar(char c)
+{
+    if (c == '\n')
+    {
+        cursor_x = 0;
+        if (cursor_y < SCREEN_ROWS - 1)
+            cursor_y++;
+        sjis_lead_pending = false;
+        return;
+    }
+    if (c == '\r')
+    {
+        cursor_x = 0;
+        sjis_lead_pending = false;
+        return;
+    }
+
+    uint8_t mapped = ascii_to_screen((uint8_t)c);
+    bool is_lead = jtxt_is_firstsjis(mapped);
+    mark_cell(cursor_x, cursor_y, mapped);
+
+    if (sjis_lead_pending)
+    {
+        sjis_lead_pending = false;
+        advance_cursor();
+    }
+    else if (is_lead)
+    {
+        sjis_lead_pending = true;
+    }
+    else
+    {
+        advance_cursor();
+    }
+}
+
+void screen_putstring(const char* s)
+{
+    while (*s)
+        screen_putchar(*s++);
+}
+
+static uint8_t translate_key(uint8_t c)
+{
+    switch (c)
+    {
+        case 145: return SCREEN_KEY_UP;
+        case 17:  return SCREEN_KEY_DOWN;
+        case 157: return SCREEN_KEY_LEFT;
+        case 29:  return SCREEN_KEY_RIGHT;
+        case 20:  return 127; /* delete */
+        case 3:   return 27;  /* RUN/STOP as ESC */
+        case 95:  return 27;  /* ← キー */
+        case 223: return 27;  /* SHIFT+← */
+        default:  return c;
+    }
+}
+
+uint16_t screen_getchar(uint16_t timeout_cs)
+{
+    (void)timeout_cs;
+    uint8_t value = kernal_getin();
+    if (value == 0)
+        return 0;
+    uint8_t key = translate_key(value);
+    if (key == SCREEN_KEY_UP || key == SCREEN_KEY_DOWN ||
+        key == SCREEN_KEY_LEFT || key == SCREEN_KEY_RIGHT)
+        return key;
+    if (key == 27 || key == 127)
+        return key;
+    uint8_t ascii = petscii_to_ascii(key);
+    if (ascii == 0)
+        return 0;
+    return ascii;
+}
+
+uint8_t screen_waitchar(void)
+{
+    uint16_t c;
+    while ((c = screen_getchar(0)) == 0)
+        ;
+    return (uint8_t)c;
+}
+
+void screen_scrollup(void)
+{
+    jtxt_bscroll_up();
+}
+
+void screen_scrolldown(void)
+{
+    /* Not used; provide a stub */
+}
+
+void screen_clear_to_eol(void)
+{
+    // Set current color and position
+    if (current_style == 1) {
+        jtxt_bcolor(status_fg_color, status_bg_color);
+    } else {
+        jtxt_bcolor(normal_fg_color, normal_bg_color);
+    }
+
+    for (uint8_t x = cursor_x; x < SCREEN_COLS; x++) {
+        jtxt_blocate(x, cursor_y);
+        jtxt_bputc(' ');
+    }
+}
+
+void screen_setstyle(uint8_t style)
+{
+    current_style = style;
+}
+
+void screen_showcursor(uint8_t show)
+{
+    // カーソル表示制御は呼び出し側で管理
+}

--- a/c/src/qe/lib/screen.h
+++ b/c/src/qe/lib/screen.h
@@ -1,0 +1,47 @@
+#ifndef SCREEN_H
+#define SCREEN_H
+
+#include <stdint.h>
+
+#define SCREEN_KEY_UP    0x8b
+#define SCREEN_KEY_DOWN  0x8a
+#define SCREEN_KEY_LEFT  0x88
+#define SCREEN_KEY_RIGHT 0x89
+
+uint8_t screen_init(void);
+void screen_shutdown(void);
+
+void screen_clear(void);
+uint16_t _screen_getsize(void);
+void _screen_setcursor(uint16_t c);
+uint16_t _screen_getcursor(void);
+void screen_putchar(char c);
+void screen_putstring(const char* s);
+uint16_t screen_getchar(uint16_t timeout_cs);
+uint8_t screen_waitchar(void);
+void screen_scrollup(void);
+void screen_scrolldown(void);
+void screen_clear_to_eol(void);
+void screen_setstyle(uint8_t style);
+void screen_showcursor(uint8_t show);
+void screen_invert_cursor(uint8_t x, uint8_t y);
+
+#define screen_setcursor(x, y) \
+    _screen_setcursor((uint16_t)((x) & 0xff) | ((uint16_t)(y) << 8))
+
+#define screen_getsize(wp, hp) \
+    do { \
+        uint16_t c = _screen_getsize(); \
+        *(wp) = c & 0xff; \
+        *(hp) = c >> 8; \
+    } while (0)
+
+#define screen_getcursor(wp, hp) \
+    do { \
+        uint16_t c = _screen_getcursor(); \
+        *(wp) = c & 0xff; \
+        *(hp) = c >> 8; \
+    } while (0)
+
+#endif
+

--- a/c/src/qe/qe.c
+++ b/c/src/qe/qe.c
@@ -1,0 +1,1436 @@
+/* qe © 2019 David Given
+ * This library is distributable under the terms of the 2-clause BSD license.
+ * See COPYING.cpmish in the distribution root directory for more information.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <ctype.h>
+#include <limits.h>
+#include "lib/screen.h"
+#ifdef QE_ENABLE_IME
+#include "ime.h"
+#endif
+#ifdef ENABLE_FILE_IO
+#include <cbm.h>
+#endif
+
+#ifndef PATH_MAX
+#define PATH_MAX 64
+#endif
+
+#define EDITOR_BUFFER_SIZE (11 * 1024)   // 11KB using high RAM at $A000-$CBFF (avoid stack at $D000)
+
+#define POKE(addr, val) (*(volatile uint8_t*)(addr) = (val))
+#define PEEK(addr) (*(volatile uint8_t*)(addr))
+
+
+uint8_t width, height;
+uint8_t viewheight;
+uint8_t status_line_length;
+void (*print_status)(const char*);
+
+static char current_filename[PATH_MAX];
+static bool filename_set = false;
+static char buffer[512];
+
+// Use high RAM for editor buffer
+static uint8_t* editor_buffer = (uint8_t*)0xA000;
+
+uint8_t* buffer_start;
+uint8_t* gap_start;
+uint8_t* gap_end;
+uint8_t* buffer_end;
+uint8_t dirty;
+
+uint8_t* first_line;   /* <= gap_start */
+uint8_t* current_line; /* <= gap_start */
+uint8_t current_line_y;
+uint8_t
+    display_height[64];   /* array of number of screen lines per logical line */
+uint16_t line_length[64]; /* array of line length per logical line */
+
+// Cursor display tracking
+static uint8_t last_cursor_x = 0xFF;  // 0xFF = no previous cursor
+static uint8_t last_cursor_y = 0xFF;
+static bool cursor_displayed = false;
+
+static void reset_cursor_display(void)
+{
+    last_cursor_x = 0xFF;
+    last_cursor_y = 0xFF;
+    cursor_displayed = false;
+}
+
+// 画面再描画時用：古いカーソル反転を元に戻してからリセット
+static void clear_and_reset_cursor_display(void)
+{
+    // リセット前に古いカーソルの反転を元に戻す
+    if (cursor_displayed && last_cursor_x != 0xFF) {
+        screen_invert_cursor(last_cursor_x, last_cursor_y);
+    }
+    reset_cursor_display();
+}
+
+static void update_cursor_display(void)
+{
+    uint8_t current_x, current_y;
+    screen_getcursor(&current_x, &current_y);
+
+    if (current_x != last_cursor_x || current_y != last_cursor_y) {
+        // Remove old cursor
+        if (cursor_displayed && last_cursor_x != 0xFF) {
+            screen_invert_cursor(last_cursor_x, last_cursor_y);
+        }
+
+        // Show new cursor
+        screen_invert_cursor(current_x, current_y);
+        cursor_displayed = true;
+        last_cursor_x = current_x;
+        last_cursor_y = current_y;
+    }
+}
+
+uint16_t command_count;
+typedef void command_t(uint16_t);
+
+struct bindings
+{
+    const char* name;
+    const char* keys;
+    command_t* const* callbacks;
+};
+
+const struct bindings* bindings;
+
+extern const struct bindings delete_bindings;
+extern const struct bindings zed_bindings;
+extern const struct bindings change_bindings;
+
+extern void colon(uint16_t count);
+extern void goto_line(uint16_t lineno);
+void goto_status_line(void);
+
+/* ======================================================================= */
+/*                           SHIFT-JIS SUPPORT                             */
+/* ======================================================================= */
+
+// Shift-JIS第1バイト判定（インライン関数で最小化）
+static inline bool is_sjis_lead(uint8_t c) {
+    return (c >= 0x81 && c <= 0x9F) || (c >= 0xE0 && c <= 0xFC);
+}
+
+// gap_startがShift-JISの2バイト目にいるかチェック
+static bool is_at_sjis_second_byte(uint8_t* pos, uint8_t* line_start) {
+    uint8_t* p = line_start;
+    while (p < pos) {
+        if (is_sjis_lead(*p)) {
+            p++; // 第1バイト
+            if (p == pos) return true;  // posは第2バイト
+            if (p < pos) p++; // 第2バイトもスキップ
+        } else {
+            p++; // ASCII文字
+        }
+    }
+    return false;
+}
+
+// 視覚列位置を簡単計算
+static uint16_t count_visual_chars(uint8_t* start, uint8_t* end) {
+    uint16_t count = 0;
+    while (start < end) {
+        if (is_sjis_lead(*start)) {
+            start += 2;
+        } else {
+            start++;
+        }
+        count++;
+    }
+    return count;
+}
+
+/* ======================================================================= */
+/*                                MISCELLANEOUS                            */
+/* ======================================================================= */
+
+void print_newline(void)
+{
+    goto_status_line();
+    screen_clear_to_eol();
+}
+
+static void append_filename(const char* path)
+{
+    size_t len = strlen(buffer);
+    if (len >= sizeof(buffer) - 1)
+        return;
+
+    size_t remaining = sizeof(buffer) - len - 1;
+    const char* text = (path && *path) ? path : "(unnamed)";
+    strncat(buffer, text, remaining);
+}
+
+static void my_strrev(char *str)
+{
+	size_t len = strlen(str);
+	for (size_t i = 0, j = len - 1; i < j; i++, j--)
+	{
+		uint8_t a = str[i];
+		str[i] = str[j];
+		str[j] = a;
+	}
+}
+
+void itoa(uint16_t val, char* buf)
+{
+    uint8_t i = 0;
+    do
+    {
+        uint8_t digit = val % 10;
+        buf[i++] = '0' + digit;
+        val /= 10;
+    } while (val);
+    buf[i] = '\0';
+    my_strrev(buf);
+}
+
+/* ======================================================================= */
+/*                                SCREEN DRAWING                           */
+/* ======================================================================= */
+
+void screen_puti(uint16_t i)
+{
+    itoa(i, buffer);
+    screen_putstring(buffer);
+}
+
+void goto_status_line(void)
+{
+    screen_setcursor(0, viewheight);
+}
+
+void set_status_line(const char* message)
+{
+    uint8_t screenx, screeny;
+    screen_getcursor(&screenx, &screeny);
+
+    uint8_t length = 0;
+    goto_status_line();
+	screen_setstyle(1);
+    for (;;)
+    {
+        char c = *message++;
+        if (!c)
+            break;
+        screen_putchar(c);
+        length++;
+    }
+	screen_setstyle(0);
+    while (length < status_line_length)
+    {
+        screen_putchar(' ');
+        length++;
+    }
+    status_line_length = length;
+    screen_setcursor(screenx, screeny);
+}
+
+/* ======================================================================= */
+/*                              BUFFER MANAGEMENT                          */
+/* ======================================================================= */
+
+void new_file(void)
+{
+    gap_start = buffer_start;
+    gap_end = buffer_end;
+
+    first_line = current_line = buffer_start;
+    dirty = true;
+}
+
+uint16_t compute_length(
+    const uint8_t* inp, const uint8_t* endp, const uint8_t** nextp)
+{
+    uint8_t xo;
+    uint8_t sjis_pending = 0;
+
+    xo = 0;
+    for (;;)
+    {
+        if (inp == endp)
+            break;
+        if (inp == gap_start)
+            inp = gap_end;
+
+        uint8_t c = *inp++;
+
+        if (sjis_pending)
+        {
+            sjis_pending = 0;
+            xo++;
+            continue;
+        }
+
+        if (c == '\n')
+            break;
+        if (c == '\t')
+            xo = (xo + 8) & ~7;
+        else if ((c >= 0x81 && c <= 0x9F) || (c >= 0xE0 && c <= 0xFC))
+            sjis_pending = 1;
+        else if (c < 32)
+            xo += 2;
+        else
+            xo++;
+    }
+
+    if (nextp)
+        *nextp = inp;
+    return xo;
+}
+
+uint8_t* draw_line(uint8_t* startp)
+{
+    uint8_t* inp = startp;
+
+    uint8_t screenx, starty;
+    screen_getcursor(&screenx, &starty);
+    uint8_t x = screenx;
+    uint8_t y = starty;
+    for (;;)
+    {
+        if (y == viewheight)
+            goto bottom_of_screen;
+
+        if (inp == gap_start)
+        {
+            inp = gap_end;
+            startp += (gap_end - gap_start);
+        }
+        if (inp == buffer_end)
+        {
+            if (x == 0)
+                screen_putchar('~');
+            break;
+        }
+
+        char c = *inp++;
+        if (c == '\n')
+            break;
+
+        if (c == '\t')
+        {
+            uint8_t spaces = (uint8_t)((((uint16_t)x / 8) + 1) * 8 - x);
+            if (spaces == 0)
+                spaces = 8;
+            for (uint8_t i = 0; i < spaces; ++i)
+                screen_putchar(' ');
+        }
+        else
+        {
+            screen_putchar(c);
+        }
+
+        screen_getcursor(&x, &y);
+    }
+
+    if (x != width)
+        screen_clear_to_eol();
+    screen_setcursor(0, y+1);
+
+bottom_of_screen:
+    display_height[starty] = y - starty + 1;
+    line_length[starty] = inp - startp;
+
+    return inp;
+}
+
+/* inp <= gap_start */
+void render_screen(uint8_t* inp)
+{
+    uint8_t x, y;
+    screen_getcursor(&x, &y);
+
+    while (y != viewheight)
+        display_height[y++] = 0;
+
+    for (;;)
+    {
+        screen_getcursor(&x, &y);
+        if (y >= viewheight)
+            break;
+
+        if (inp == current_line)
+            current_line_y = y;
+
+        inp = draw_line(inp);
+    }
+
+    // 画面再描画後にカーソル追跡をリセット（古いカーソル表示は自然に上書きされる）
+    reset_cursor_display();
+}
+
+void adjust_scroll_position(void)
+{
+    uint8_t total_height = 0;
+
+    first_line = current_line;
+    while (first_line != buffer_start)
+    {
+        uint8_t* line_start = first_line;
+        const uint8_t* line_end = line_start--;
+        while ((line_start != buffer_start) && (line_start[-1] != '\n'))
+            line_start--;
+
+        total_height +=
+            (compute_length(line_start, line_end, NULL) / width) + 1;
+        if (total_height > (viewheight / 2))
+            break;
+        first_line = line_start;
+    }
+
+    screen_setcursor(0, 0);
+    render_screen(first_line);
+}
+
+void recompute_screen_position(void)
+{
+    const uint8_t* inp;
+
+    if (current_line < first_line)
+        adjust_scroll_position();
+
+    for (;;)
+    {
+        inp = first_line;
+        current_line_y = 0;
+        while (current_line_y < viewheight)
+        {
+            if (inp == current_line)
+                break;
+
+            uint8_t h = display_height[current_line_y];
+            inp += line_length[current_line_y];
+
+            current_line_y += h;
+        }
+
+        if ((current_line_y >= viewheight) ||
+            ((current_line_y + display_height[current_line_y]) > viewheight))
+        {
+            adjust_scroll_position();
+        }
+        else
+            break;
+    }
+
+    uint8_t length = compute_length(current_line, gap_start, NULL);
+    screen_setcursor(length % width, current_line_y + (length / width));
+}
+
+void redraw_current_line(void)
+{
+    uint8_t* nextp;
+    uint8_t oldheight;
+
+    oldheight = display_height[current_line_y];
+    screen_setcursor(0, current_line_y);
+    nextp = draw_line(current_line);
+    if (oldheight != display_height[current_line_y])
+        render_screen(nextp);
+    else
+        // render_screen()が呼ばれない場合もカーソル追跡をリセット
+        reset_cursor_display();
+
+    recompute_screen_position();
+}
+
+/* ======================================================================= */
+/*                                LIFECYCLE                                */
+/* ======================================================================= */
+
+static void format_status_with_path(const char* prefix, const char* path)
+{
+    strncpy(buffer, prefix, sizeof(buffer) - 1);
+    buffer[sizeof(buffer) - 1] = '\0';
+    append_filename(path);
+    print_status(buffer);
+}
+
+static bool insert_file(const char* path)
+{
+#ifdef ENABLE_FILE_IO
+    if (!path || !*path)
+        return false;
+
+    format_status_with_path("Reading ", path);
+
+    // Set filename for KERNAL
+    cbm_k_setnam(path);
+
+    // Set logical file parameters (LFN=1, Device=8, Secondary=0 for read)
+    cbm_k_setlfs(1, 8, 0);
+
+    // Load file to current gap position
+    // flag=0 means load, not verify
+    void* end_addr = cbm_k_load(0, gap_start);
+
+    // Check for error (high byte of return address < $20 indicates error)
+    if ((uint16_t)end_addr < 0x2000)
+    {
+        print_status("Load failed");
+        return false;
+    }
+
+    // Calculate how many bytes were loaded
+    uint16_t bytes_loaded = (uint8_t*)end_addr - gap_start;
+
+    // Update gap_start to point after loaded data
+    gap_start += bytes_loaded;
+
+    // Convert CR to LF
+    uint8_t* p = gap_start - bytes_loaded;
+    while (p < gap_start)
+    {
+        if (*p == '\r')
+            *p = '\n';
+        p++;
+    }
+
+    if (bytes_loaded > 0)
+        dirty = true;
+
+    return true;
+#else
+    (void)path;
+    print_status("File I/O disabled");
+    return false;
+#endif
+}
+
+void load_file(void)
+{
+    new_file();
+    if (filename_set)
+        insert_file(current_filename);
+    dirty = false;
+    goto_line(1);
+}
+
+bool save_file(void)
+{
+#ifdef ENABLE_FILE_IO
+    if (!filename_set)
+    {
+        print_status("No filename set");
+        return false;
+    }
+
+    format_status_with_path("Writing ", current_filename);
+
+    // Set filename for KERNAL
+    cbm_k_setnam(current_filename);
+
+    // Set logical file parameters (LFN=1, Device=8, Secondary=1 for write)
+    cbm_k_setlfs(1, 8, 1);
+
+    // Calculate buffer range to save
+    // We need to save from buffer_start to gap_start, then gap_end to buffer_end
+    // But KERNAL save needs continuous memory, so we need to compact first
+
+    // Move gap to end of buffer to make data continuous
+    while (gap_end != buffer_end)
+        *gap_start++ = *gap_end++;
+
+    // Now all data is continuous from buffer_start to gap_start
+    uint8_t result = cbm_k_save(buffer_start, gap_start);
+
+    // Restore gap position (move gap back to current position)
+    // This is simplified - in real use we'd need to track original gap position
+
+    bool ok = (result == 0);
+    if (!ok)
+    {
+        print_status("Save failed");
+    }
+
+#else
+    print_status("File I/O disabled");
+    bool ok = false;
+#endif
+
+    if (ok)
+    {
+        dirty = false;
+        print_status("File saved");
+    }
+
+    return ok;
+}
+
+void quit(void)
+{
+    screen_shutdown();
+
+    // Restore normal memory configuration
+    POKE(0x01, 0x37);
+
+    // Restore KERNAL vectors and I/O
+    __asm__("jsr $FF8A");  // RESTOR: Restore vectors
+    __asm__("jsr $FF81");  // CINT: Initialize screen editor
+    __asm__("jsr $FF84");  // IOINIT: Initialize I/O
+
+    __asm__("ldx #$ff");
+    __asm__("txs");
+
+    __asm__("jmp $FCE2");
+    //exit(0);
+}
+
+/* ======================================================================= */
+/*                            EDITOR OPERATIONS                            */
+/* ======================================================================= */
+
+void cursor_home(uint16_t count)
+{
+    (void)count;
+    while (gap_start != current_line)
+        *--gap_end = *--gap_start;
+}
+
+void cursor_end(uint16_t count)
+{
+    (void)count;
+    while ((gap_end != buffer_end) && (gap_end[0] != '\n'))
+        *gap_start++ = *gap_end++;
+}
+
+void cursor_left(uint16_t count)
+{
+    while (count--)
+    {
+        if ((gap_start != buffer_start) && (gap_start[-1] != '\n'))
+        {
+            *--gap_end = *--gap_start;
+
+            // Shift-JISの2バイト目に着地した場合、1バイト目まで戻る
+            if (is_at_sjis_second_byte(gap_start, current_line))
+                *--gap_end = *--gap_start;
+        }
+    }
+}
+
+void cursor_right(uint16_t count)
+{
+    while (count--)
+    {
+        if ((gap_end != buffer_end) && (gap_end[0] != '\n'))
+        {
+            uint8_t c = *gap_start++ = *gap_end++;
+
+            // Shift-JIS第1バイトなら、第2バイトも移動
+            if (is_sjis_lead(c) && gap_end != buffer_end && *gap_end != '\n')
+                *gap_start++ = *gap_end++;
+        }
+    }
+}
+
+void cursor_down(uint16_t count)
+{
+    while (count--)
+    {
+        uint16_t visual_col = count_visual_chars(current_line, gap_start);
+        cursor_end(1);
+        if (gap_end == buffer_end)
+            return;
+
+        *gap_start++ = *gap_end++;
+        current_line = gap_start;
+        cursor_right(visual_col);
+    }
+}
+
+void cursor_up(uint16_t count)
+{
+    while (count--)
+    {
+        uint16_t visual_col = count_visual_chars(current_line, gap_start);
+
+        cursor_home(1);
+        if (gap_start == buffer_start)
+            return;
+
+        do
+            *--gap_end = *--gap_start;
+        while ((gap_start != buffer_start) && (gap_start[-1] != '\n'));
+
+        current_line = gap_start;
+        cursor_right(visual_col);
+    }
+}
+
+
+
+
+void insert_newline(void)
+{
+    if (gap_start != gap_end)
+    {
+        *gap_start++ = '\n';
+        screen_setcursor(0, current_line_y);
+
+        // 改行挿入後は複数行を再描画する必要がある
+        render_screen(current_line);
+
+        // 新しい行に移動
+        current_line = gap_start;
+        recompute_screen_position();
+    }
+}
+
+static bool insert_key(uint8_t key, bool replacing)
+{
+    if (key == 127)
+    {
+        if (gap_start != current_line)
+        {
+            // Shift-JIS対応：バックスペース処理
+            gap_start--;  // まず1バイト削除
+
+            // 削除後の位置が全角文字の2バイト目になった場合、1バイト目も削除
+            if (gap_start > current_line && is_at_sjis_second_byte(gap_start, current_line))
+            {
+                gap_start--;  // 1バイト目も削除
+            }
+
+            return true;
+        }
+        return false;
+    }
+
+    if (gap_start == gap_end)
+        return false;
+
+    if (replacing && (gap_end != buffer_end) && (*gap_end != '\n'))
+    {
+        uint8_t c = *gap_end;
+        gap_end++;
+        // Shift-JIS第1バイトなら第2バイトも削除
+        if (is_sjis_lead(c) && gap_end != buffer_end && *gap_end != '\n')
+            gap_end++;
+    }
+
+    if (key == 13)
+    {
+        insert_newline();
+        return true;
+    }
+
+    *gap_start++ = key;
+    return true;
+}
+
+#ifdef QE_ENABLE_IME
+static bool insert_bytes(const uint8_t* data, uint8_t length, bool replacing)
+{
+    bool modified = false;
+
+    if (!data || length == 0)
+        return false;
+
+    for (uint8_t i = 0; i < length; ++i)
+    {
+        if (insert_key(data[i], replacing))
+        {
+            modified = true;
+        }
+        else if (gap_start == gap_end)
+        {
+            break;
+        }
+    }
+
+    return modified;
+}
+
+static bool process_ime_insert(bool replacing)
+{
+    for (;;)
+    {
+        uint8_t event = ime_process();
+
+        switch (event)
+        {
+            case IME_EVENT_NONE:
+                if (ime_is_active())
+                    continue;
+                return false;
+
+            case IME_EVENT_CONFIRMED:
+            {
+                const uint8_t* text = ime_get_result_text();
+                uint8_t length = ime_get_result_length();
+                if (insert_bytes(text, length, replacing))
+                {
+                    dirty = true;
+                    redraw_current_line();
+                }
+                ime_clear_output();
+                return true;
+            }
+
+            case IME_EVENT_KEY_PASSTHROUGH:
+            {
+                uint8_t key = ime_get_passthrough_key();
+                if (key == 20)
+                    key = 127;
+                if (key <= 127 && insert_key(key, replacing))
+                {
+                    dirty = true;
+                    // 改行の場合はinsert_newline()内で再描画するため、ここでは再描画しない
+                    if (key != 13)
+                        redraw_current_line();
+                }
+                return true;
+            }
+
+            case IME_EVENT_MODE_CHANGED:
+                // モード変更（ひらがな⇔カタカナ）はIME継続
+                return true;
+
+            case IME_EVENT_CANCELLED:
+            case IME_EVENT_DEACTIVATED:
+                // IME無効化時は通常入力に戻る
+                return false;
+
+            default:
+                return true;
+        }
+    }
+}
+#endif
+
+static void set_insert_status(bool replacing)
+{
+    goto_status_line();
+    screen_setstyle(0);
+    screen_clear_to_eol();
+    set_status_line(replacing ? "Replace mode" : "Insert mode");
+}
+
+void insert_mode(bool replacing)
+{
+    set_insert_status(replacing);
+
+#ifdef QE_ENABLE_IME
+    bool ime_was_active = false;
+#endif
+
+    for (;;)
+    {
+#ifdef QE_ENABLE_IME
+        if (process_ime_insert(replacing))
+        {
+            ime_was_active = true;
+            update_cursor_display();
+            continue;
+        }
+        // IME無効化後のみステータスラインを再設定
+        if (ime_was_active)
+        {
+            set_insert_status(replacing);
+            ime_was_active = false;
+        }
+#endif
+
+        uint8_t c = screen_waitchar();
+        if (c == 27)
+            break;
+        if (c > 127)
+            continue;
+
+        if (insert_key(c, replacing))
+        {
+            dirty = true;
+            // 改行の場合はinsert_newline()内で再描画するため、ここでは再描画しない
+            if (c != 13)
+                redraw_current_line();
+        }
+
+        // 文字入力後にカーソル表示を更新
+        update_cursor_display();
+    }
+
+    set_status_line("");
+}
+
+void insert_text(uint16_t count)
+{
+    (void)count;
+    insert_mode(false);
+}
+
+void append_text(uint16_t count)
+{
+    cursor_end(1);
+    recompute_screen_position();
+    insert_text(count);
+}
+
+void goto_line(uint16_t lineno)
+{
+    while (gap_start != buffer_start)
+        *--gap_end = *--gap_start;
+    current_line = buffer_start;
+
+    while ((gap_end != buffer_end) && --lineno)
+    {
+        while (gap_end != buffer_end)
+        {
+            uint16_t c = *gap_start++ = *gap_end++;
+            if (c == '\n')
+            {
+                current_line = gap_start;
+                break;
+            }
+        }
+    }
+}
+
+void delete_right(uint16_t count)
+{
+    while (count--)
+    {
+        if (gap_end == buffer_end)
+            break;
+
+        // Shift-JIS対応：カーソル位置の文字を確認
+        if (is_sjis_lead(*gap_end)) {
+            // 全角文字の1文字目なら2バイト削除
+            gap_end++;
+            if (gap_end < buffer_end)
+                gap_end++;
+        } else {
+            // 半角文字または全角文字の2文字目なら1バイト削除
+            gap_end++;
+        }
+    }
+
+    redraw_current_line();
+    dirty = true;
+}
+
+void delete_rest_of_line(uint16_t count)
+{
+    while ((gap_end != buffer_end) && (gap_end[0] != '\n'))
+        gap_end++;
+
+    if (count != 0)
+        redraw_current_line();
+    dirty = true;
+}
+
+void delete_line(uint16_t count)
+{
+    while (count--)
+    {
+        cursor_home(1);
+        delete_rest_of_line(0);
+        if (gap_end != buffer_end)
+        {
+            gap_end++;
+            display_height[current_line_y] = 0;
+        }
+    }
+
+    redraw_current_line();
+    dirty = true;
+}
+
+
+
+void change_rest_of_line(uint16_t count)
+{
+    delete_rest_of_line(1);
+    insert_text(count);
+}
+
+void join(uint16_t count)
+{
+    while (count--)
+    {
+        uint8_t* ptr = gap_end;
+        while ((ptr != buffer_end) && (*ptr != '\n'))
+            ptr++;
+
+        if (ptr != buffer_end)
+            *ptr = ' ';
+    }
+
+    screen_setcursor(0, current_line_y);
+    render_screen(current_line);
+    dirty = true;
+}
+
+void open_above(uint16_t count)
+{
+    if (gap_start == gap_end)
+        return;
+
+    cursor_home(1);
+    *--gap_end = '\n';
+
+    recompute_screen_position();
+    screen_setcursor(0, current_line_y);
+
+    // render_screen前に古いカーソルをクリア
+    clear_and_reset_cursor_display();
+    render_screen(current_line);
+    recompute_screen_position();
+
+    // カーソル表示を明示的に更新
+    update_cursor_display();
+
+    insert_text(count);
+}
+
+void open_below(uint16_t count)
+{
+    cursor_down(1);
+    open_above(count);
+}
+
+void replace_char(uint16_t count)
+{
+    (void)count;
+    uint8_t c = screen_waitchar();
+
+    if (gap_end == buffer_end)
+        return;
+    if (c == '\n')
+    {
+        gap_end++;
+        /* The cursor ends up *after* the newline. */
+        insert_newline();
+    }
+    else if (isprint(c))
+    {
+        *gap_end = c;
+        /* The cursor ends on *on* the replace character. */
+        redraw_current_line();
+    }
+}
+
+void replace_line(uint16_t count)
+{
+    (void)count;
+    insert_mode(true);
+}
+
+void zed_save_and_quit(uint16_t count)
+{
+    (void)count;
+    if (!dirty)
+        quit();
+    if (!filename_set)
+    {
+        set_status_line("No filename set");
+        return;
+    }
+    if (save_file())
+        quit();
+}
+
+void zed_force_quit(uint16_t count)
+{
+    (void)count;
+    quit();
+}
+
+void redraw_screen(uint16_t count)
+{
+    (void)count;
+    screen_clear();
+    render_screen(first_line);
+}
+
+void enter_delete_mode(uint16_t count)
+{
+    bindings = &delete_bindings;
+    command_count = count;
+}
+
+void enter_zed_mode(uint16_t count)
+{
+    bindings = &zed_bindings;
+    command_count = count;
+}
+
+void enter_change_mode(uint16_t count)
+{
+    bindings = &change_bindings;
+    command_count = count;
+}
+
+// デバッグ: gapアドレス表示
+void show_gap_debug(uint16_t count)
+{
+    (void)count;
+    char buf[32];
+    buf[0] = 'S';
+    buf[1] = ':';
+
+    // gap_start表示
+    uint16_t addr = (uint16_t)gap_start;
+    for (int i = 3; i >= 0; i--) {
+        uint8_t n = (addr >> (i * 4)) & 0xF;
+        buf[5-i] = (n < 10) ? ('0' + n) : ('A' + n - 10);
+    }
+
+    buf[6] = ' ';
+    buf[7] = 'E';
+    buf[8] = ':';
+
+    // gap_end表示
+    addr = (uint16_t)gap_end;
+    for (int i = 3; i >= 0; i--) {
+        uint8_t n = (addr >> (i * 4)) & 0xF;
+        buf[12-i] = (n < 10) ? ('0' + n) : ('A' + n - 10);
+    }
+
+    buf[13] = '\0';
+    set_status_line(buf);
+}
+
+const char normal_keys[] = "^$hjkliAGxJOorR:\022dZcD\210\211\212\213";
+
+command_t* const normal_cbs[] = {
+    cursor_home,
+    cursor_end,
+    cursor_left,
+    cursor_down,
+    cursor_up,
+    cursor_right,
+    insert_text,
+    append_text,
+    goto_line,
+    delete_right,
+    join,
+    open_above,
+    open_below,
+    replace_char,
+    replace_line,
+    colon,
+    redraw_screen,
+    enter_delete_mode,
+    enter_zed_mode,
+    enter_change_mode,
+    show_gap_debug,  // Dキーでデバッグ表示
+    cursor_left,
+    cursor_right,
+    cursor_down,
+    cursor_up,
+};
+
+const struct bindings normal_bindings = {NULL, normal_keys, normal_cbs};
+
+const char delete_keys[] = "d$";
+command_t* const delete_cbs[] = {
+    delete_line,
+    delete_rest_of_line,
+};
+
+const struct bindings delete_bindings = {"Delete", delete_keys, delete_cbs};
+
+const char change_keys[] = "$";
+command_t* const change_cbs[] = {
+    change_rest_of_line,
+};
+
+const struct bindings change_bindings = {"Change", change_keys, change_cbs};
+
+const char zed_keys[] = "ZQ";
+command_t* const zed_cbs[] = {
+    zed_save_and_quit,
+    zed_force_quit,
+};
+
+const struct bindings zed_bindings = {"Zed", zed_keys, zed_cbs};
+
+/* ======================================================================= */
+/*                             COLON COMMANDS                              */
+/* ======================================================================= */
+
+void set_current_filename(const char* f)
+{
+    if (!f || !*f)
+    {
+        filename_set = false;
+        current_filename[0] = '\0';
+        return;
+    }
+
+    strncpy(current_filename, f, sizeof(current_filename) - 1);
+    current_filename[sizeof(current_filename) - 1] = '\0';
+    filename_set = true;
+    dirty = true;
+}
+
+void print_no_filename(void)
+{
+    set_status_line("No filename set");
+}
+
+void print_document_not_saved(void)
+{
+    set_status_line("Not saved! Use :e! to force");
+}
+
+void print_colon_status(const char* s)
+{
+    set_status_line(s);
+}
+
+static bool read_colon_input(char* out, size_t maxlen)
+{
+    size_t len = 0;
+    for (;;)
+    {
+        uint8_t c = screen_waitchar();
+        if (c == 27)
+        {
+            out[0] = '\0';
+            return false;
+        }
+        if (c == '\r')
+        {
+            out[len] = '\0';
+            return len != 0;
+        }
+        if ((c == 127 || c == '\b') && len > 0)
+        {
+            len--;
+            screen_setcursor((uint8_t)(1 + len), viewheight);
+            screen_putchar(' ');
+            screen_setcursor((uint8_t)(1 + len), viewheight);
+            continue;
+        }
+        if (isprint(c) && len < maxlen - 1)
+        {
+            out[len++] = (char)c;
+            screen_putchar((char)c);
+        }
+    }
+}
+
+void colon(uint16_t count)
+{
+    (void)count;
+    print_status = print_colon_status;
+
+    for (;;)
+    {
+        update_cursor_display();
+        goto_status_line();
+        screen_setstyle(1);
+        screen_putstring(":");
+        screen_clear_to_eol();
+        screen_setstyle(0);
+        screen_setcursor(1, viewheight);
+        screen_showcursor(1);
+
+        char input[128];
+        bool have_input = read_colon_input(input, sizeof(input));
+        print_newline();
+
+        if (!have_input)
+            break;
+
+        char* w = strtok(input, " ");
+        if (!w)
+            continue;
+        char* arg = strtok(NULL, " ");
+
+        switch (*w)
+        {
+            case 'w':
+            {
+                bool quitting = w[1] == 'q';
+                if (arg)
+                    set_current_filename(arg);
+                if (!filename_set)
+                    print_no_filename();
+                else if (save_file() && quitting)
+                    quit();
+                break;
+            }
+
+            case 'r':
+            {
+                if (arg)
+                    insert_file(arg);
+                else
+                    print_no_filename();
+                break;
+            }
+
+            case 'e':
+            {
+                if (!arg)
+                {
+                    print_no_filename();
+                    break;  // コマンドのbreakではなく、switch文のbreak
+                }
+                else if (dirty && (w[1] != '!'))
+                {
+                    print_document_not_saved();
+                    // エラー時は単にbreakして、メッセージを表示したまま通常モードに戻る
+                    goto colon_exit;
+                }
+                else
+                {
+                    set_current_filename(arg);
+                    if (filename_set)
+                        load_file();
+                }
+                break;
+            }
+
+            case 'p':
+            {
+                strcpy(buffer, "File: ");
+                append_filename(filename_set ? current_filename : NULL);
+                print_colon_status(buffer);
+                break;
+            }
+
+            case 'n':
+            {
+                if (dirty && (w[1] != '!'))
+                    print_document_not_saved();
+                else
+                {
+                    new_file();
+                    filename_set = false;
+                    current_filename[0] = '\0';
+                    dirty = false;
+                }
+                break;
+            }
+
+            case 'q':
+            {
+                if (!dirty || (w[1] == '!'))
+                    quit();
+                else
+                    print_document_not_saved();
+                break;
+            }
+
+            default:
+                set_status_line("Unknown command");
+        }
+    }
+
+    screen_clear();
+    screen_showcursor(1);
+    print_status = set_status_line;
+    render_screen(first_line);
+    return;
+
+colon_exit:
+    screen_showcursor(1);
+    print_status = set_status_line;
+    // エラー時は画面をクリアしない（メッセージを残すため）
+}
+
+/* ======================================================================= */
+/*                            EDITOR OPERATIONS                            */
+/* ======================================================================= */
+
+int main(void)
+{
+#ifdef QE_ENABLE_IME
+    ime_init();
+#endif
+
+    screen_init();
+    screen_clear();
+
+    // Continue with original QE functionality
+    buffer_start = editor_buffer;
+    buffer_end = editor_buffer + EDITOR_BUFFER_SIZE;
+
+    // LO ROM
+    // HIGH RAM
+    POKE(0x01, (PEEK(0x01) & 0xfc) | 0x02);
+
+
+    screen_getsize(&width, &height);
+    width += 1;
+    height += 1;
+    viewheight = height - 1;
+    status_line_length = 0;
+    print_status = set_status_line;
+
+    new_file();
+
+    screen_setcursor(0, 0);
+    render_screen(first_line);
+    bindings = &normal_bindings;
+
+    command_count = 0;
+    for (;;)
+    {
+        recompute_screen_position();
+        update_cursor_display();
+
+        char c;
+        for (;;)
+        {
+            c = screen_waitchar();
+            if (isdigit(c))
+            {
+                command_count = (command_count * 10) + (c - '0');
+                itoa(command_count, buffer);
+                strcat(buffer, " repeat");
+                set_status_line(buffer);
+            }
+            else
+            {
+                set_status_line("");
+                break;
+            }
+        }
+
+        const char* cmdp = strchr(bindings->keys, c);
+        if (cmdp)
+        {
+            command_t* cmd = bindings->callbacks[cmdp - bindings->keys];
+            uint16_t count = command_count;
+            if (count == 0)
+            {
+                if (cmd == goto_line)
+                    count = UINT16_MAX;
+                else
+                    count = 1;
+            }
+            command_count = 0;
+
+            bindings = &normal_bindings;
+            set_status_line("");
+            cmd(count);
+            if (bindings->name)
+                set_status_line(bindings->name);
+        }
+        else
+        {
+            set_status_line("Unknown key");
+            bindings = &normal_bindings;
+            command_count = 0;
+        }
+    }
+    return 0;
+}

--- a/c/test/test_jtxt.c
+++ b/c/test/test_jtxt.c
@@ -1,0 +1,157 @@
+#include <c64.h>
+#include <string.h>
+#include "jtxt.h"
+
+#define PEEK(addr) (*(volatile unsigned char*)(addr))
+#define POKE(addr, val) (*(volatile unsigned char*)(addr) = (val))
+
+// Test bitmap mode
+static void test_bitmap_mode(void) {
+    jtxt_set_mode(JTXT_BITMAP_MODE);
+    jtxt_bcls();
+
+    // Set colors
+    jtxt_bcolor(1, 0);  // White on black
+
+    // Test ASCII text
+    jtxt_blocate(5, 2);
+    jtxt_bputs("Bitmap Mode Test");
+
+    // Test Japanese text
+    jtxt_blocate(5, 4);
+    // const char japanese[] = {
+    //     0x93, 0xFA, 0x96, 0x7B, 0x8C, 0xEA, // “ú–{Œê
+    //     0x00
+    // };
+    const char japanese[] = "‚±‚ñ‚É‚¿‚ÍŠ¿ŽšãOŸ~åKåN—Ú—ž";
+    jtxt_bputs(japanese);
+
+    // Test window functionality
+    jtxt_bwindow(10, 20);
+    jtxt_bwindow_enable();
+
+    jtxt_blocate(0, 10);
+    jtxt_bputs("Window test line 1");
+    jtxt_bnewline();
+    jtxt_bputs("Window test line 2");
+
+    // Test hex and decimal output
+    jtxt_blocate(0, 15);
+    jtxt_bputs("Hex: ");
+    jtxt_bput_hex2(0xAB);
+    jtxt_bputs(" Dec: ");
+    jtxt_bput_dec3(255);
+
+    // Wait for key
+    while (PEEK(0xC6) == 0);
+    POKE(0xC6, 0);  // Clear key buffer
+}
+
+// Test text mode
+static void test_text_mode(void) {
+    jtxt_set_mode(JTXT_TEXT_MODE);
+    jtxt_cls();
+
+    // Test colors
+    jtxt_set_bgcolor(6, 14);  // Blue background, light blue border
+
+    // Test different colors
+    jtxt_set_color(1);
+    jtxt_locate(5, 2);
+    jtxt_puts("Text Mode Test");
+
+    // Test kanji
+    jtxt_set_color(7);
+    jtxt_locate(5, 4);
+    const char kanji[] = {
+        0x8A, 0xBF, 0x8E, 0x9A, // Š¿Žš
+        0x00
+    };
+    jtxt_puts(kanji);
+
+    // Test mixed text
+    jtxt_set_color(3);
+    jtxt_locate(5, 6);
+    jtxt_puts("Mix: ");
+    const char mixed[] = {
+        'A', 'B', 'C', ' ',
+        0xB1, 0xB2, 0xB3, ' ',  // Half-width katakana ƒA ƒC ƒE
+        0x82, 0x50, 0x82, 0x51, // Full-width ‚P‚Q
+        0x00
+    };
+    jtxt_puts(mixed);
+
+    // Test newline
+    jtxt_set_color(5);
+    jtxt_locate(5, 8);
+    jtxt_puts("Line 1");
+    jtxt_newline();
+    jtxt_puts("     Line 2 after newline");
+
+    // Test character range setting
+    jtxt_set_range(64, 32);
+    jtxt_locate(5, 12);
+    jtxt_puts("Custom range test");
+
+    // Wait for key
+    while (PEEK(0xC6) == 0);
+    POKE(0xC6, 0);
+}
+
+// Test Shift-JIS state handling
+static void test_sjis_state(void) {
+    jtxt_cls();
+    jtxt_locate(5, 2);
+    jtxt_puts("Shift-JIS State Test");
+
+    // Test incomplete Shift-JIS sequence
+    jtxt_locate(5, 4);
+    jtxt_putc(0x82);  // First byte of Shift-JIS
+    jtxt_putc(0x20);  // Invalid second byte (should reset)
+    jtxt_puts("ABC");  // Should display normally
+
+    // Test valid Shift-JIS sequence
+    jtxt_locate(5, 6);
+    jtxt_putc(0x82);  // First byte
+    jtxt_putc(0xA0);  // Valid second byte (‚ )
+    jtxt_puts(" OK");
+
+    // Test is_firstsjis function
+    jtxt_locate(5, 8);
+    if (jtxt_is_firstsjis(0x82)) {
+        jtxt_puts("0x82 is first byte: OK");
+    }
+
+    jtxt_locate(5, 10);
+    if (!jtxt_is_firstsjis(0x41)) {
+        jtxt_puts("0x41 is not first byte: OK");
+    }
+
+    // Wait for key
+    while (PEEK(0xC6) == 0);
+    POKE(0xC6, 0);
+}
+
+int main(void) {
+    // Initialize library
+    jtxt_init(JTXT_TEXT_MODE);
+
+    // Run tests
+    test_text_mode();
+    test_bitmap_mode();
+    test_sjis_state();
+
+    // Final cleanup
+    jtxt_cleanup();
+
+    // Show completion message
+    jtxt_cls();
+    jtxt_locate(10, 10);
+    jtxt_puts("All tests completed!");
+    jtxt_locate(10, 12);
+    jtxt_puts("Press any key to exit");
+
+    while (PEEK(0xC6) == 0);
+
+    return 0;
+}

--- a/prog8/src/hello.p8
+++ b/prog8/src/hello.p8
@@ -7,13 +7,12 @@
 main {
     
     sub start() {
-        ; 日本語テキストライブラリ初期化（文字128-191を使用、モード0）
-        jtxt.init(128, 64, 0)
+        ; 日本語テキストライブラリ初期化（モード0）
+        jtxt.init(0)
         
         ; 画面クリアと初期設定
         jtxt.cls()
-        jtxt.set_bgcolor(0)        ; 黒い背景
-        jtxt.set_bordercolor(6)    ; 青いボーダー
+        jtxt.set_bgcolor(0, 6)     ; 背景=黒, ボーダー=青
         jtxt.set_color(1)          ; 白い文字
         
         ; タイトル表示
@@ -34,8 +33,7 @@ main {
         txt.print(iso:"JAPANESE MESSAGE:")
         
         ; 日本語メッセージを画面中央に表示
-        jtxt.set_bgcolor(6)        ; 青い背景
-        jtxt.set_bordercolor(14)   ; ライトブルーのボーダー
+        jtxt.set_bgcolor(6, 14)    ; 背景=青, ボーダー=ライトブルー
         jtxt.set_color(7)          ; 黄色い文字
         jtxt.locate(5, 10)
         jtxt.puts(&hello_message)
@@ -56,8 +54,7 @@ main {
         ; 画面をクリアして別の色で表示(全てjtxtで表示)
         jtxt.cls()
         
-        jtxt.set_bgcolor(0)        ; 黒い背景
-        jtxt.set_bordercolor(0)    ; 黒いボーダー
+        jtxt.set_bgcolor(0, 0)     ; 背景=黒, ボーダー=黒
         jtxt.set_color(10)         ; ライトレッドの文字
         jtxt.locate(3, 8)
         jtxt.puts(&hello_message)

--- a/prog8/src/hello_bitmap.p8
+++ b/prog8/src/hello_bitmap.p8
@@ -9,6 +9,9 @@ main {
     sub start() {
         ; 日本語テキストライブラリ初期化（テキストモード）
         jtxt.init(jtxt.TEXT_MODE)
+        jtxt.bwindow(0, 24);
+        jtxt.bwindow_disable();
+        jtxt.bwindow_enable();
         
         ; 画面クリアと初期設定
         jtxt.cls()

--- a/prog8/src/hello_bitmap.p8
+++ b/prog8/src/hello_bitmap.p8
@@ -7,13 +7,12 @@
 main {
     
     sub start() {
-        ; 日本語テキストライブラリ初期化（文字128-191を使用、テキストモード）
-        jtxt.init(128, 64, jtxt.TEXT_MODE)
+        ; 日本語テキストライブラリ初期化（テキストモード）
+        jtxt.init(jtxt.TEXT_MODE)
         
         ; 画面クリアと初期設定
         jtxt.cls()
-        jtxt.set_bgcolor(0)        ; 黒い背景
-        jtxt.set_bordercolor(6)    ; 青いボーダー
+        jtxt.set_bgcolor(0, 6)     ; 背景=黒, ボーダー=青
         jtxt.set_color(1)          ; 白い文字
         
         ; タイトル表示

--- a/prog8/src/hello_resource.p8
+++ b/prog8/src/hello_resource.p8
@@ -7,13 +7,12 @@
 main {
     
     sub start() {
-        ; 日本語テキストライブラリ初期化（文字33-227を使用、テキストモード）
-        jtxt.init(33, 200, 0)
+        ; 日本語テキストライブラリ初期化（テキストモード）
+        jtxt.init(0)
         
         ; 画面クリアと色設定
         jtxt.cls()
-        jtxt.set_bgcolor(0)        ; 黒い背景
-        jtxt.set_bordercolor(6)    ; 青いボーダー
+        jtxt.set_bgcolor(0, 6)     ; 背景=黒, ボーダー=青
         jtxt.set_color(1)          ; 白
         
         ; タイトル表示

--- a/prog8/src/ime.p8
+++ b/prog8/src/ime.p8
@@ -261,8 +261,7 @@ ime {
     ; ブロッキング型IME用変数
     ubyte saved_cursor_x               ; process開始時のカーソルX位置
     ubyte saved_cursor_y               ; process開始時のカーソルY位置
-    ubyte saved_fg_color               ; process開始時のfg色
-    ubyte saved_bg_color               ; process開始時のbg色
+    ubyte saved_color                  ; process開始時のテキスト色(fg & bg)
 
     ubyte passthrough_key              ; パススルーするキーコード
     
@@ -2417,15 +2416,14 @@ ime {
     }
 
     sub backup_cursor() {
-        saved_cursor_x = jtxt.bitmap_x
-        saved_cursor_y = jtxt.bitmap_y
-        saved_fg_color = jtxt.bitmap_fg_color
-        saved_bg_color = jtxt.bitmap_bg_color
+        saved_cursor_x = jtxt.cursor_x
+        saved_cursor_y = jtxt.cursor_y
+        saved_color = jtxt.bitmap_color
     }
 
     sub restore_cursor() {
         jtxt.blocate(saved_cursor_x, saved_cursor_y)
-        jtxt.bcolor(saved_fg_color, saved_bg_color)
+        jtxt.bcolor(saved_color >> 4, saved_color & 15)
     }
     
     ; ノンブロッキングIME処理（メイン関数）

--- a/prog8/src/ime_test.p8
+++ b/prog8/src/ime_test.p8
@@ -14,8 +14,8 @@ main {
         ; IME初期化
         ime.init()
         
-        ; jtxtライブラリ初期化（文字範囲64-254、190文字使用、ビットマップモード）
-        jtxt.init(64, 190, jtxt.BITMAP_MODE)
+        ; jtxtライブラリ初期化（ビットマップモード）
+        jtxt.init(jtxt.BITMAP_MODE)
 
         ; タイトル表示
         show_title()

--- a/prog8/src/jtxt.p8
+++ b/prog8/src/jtxt.p8
@@ -54,12 +54,9 @@ jtxt {
     ubyte bitmap_bottom_row = 24        ; 描画終了行（デフォルト: 24）
     bool bitmap_window_enabled = false ; 行範囲制御有効フラグ
     
-    ; ハードウェア初期化（文字範囲・モードも同時設定）
-    sub init(ubyte start_char, ubyte char_count, ubyte mode) {
-        ; 文字範囲設定
-        set_range(start_char, char_count)
-        
-        ; 表示モード設定
+    ; ハードウェア初期化（モード設定のみ、文字範囲はデフォルトを使用）
+    sub init(ubyte mode) {
+        ; 表示モード設定（chr_start/chr_count はデフォルト値を使用）
         set_mode(mode)
         
         ; MagicDeskをバンク0に設定
@@ -223,14 +220,10 @@ jtxt {
         current_color = color & 15  ; 下位4ビットのみ有効
     }
     
-    ; 背景色設定
-    sub set_bgcolor(ubyte color) {
-        @($D021) = color & 15  ; 背景色レジスタに設定
-    }
-    
-    ; ボーダー色設定
-    sub set_bordercolor(ubyte color) {
-        @($D020) = color & 15  ; ボーダー色レジスタに設定
+    ; 背景色/ボーダー色設定（2引数に統合）
+    sub set_bgcolor(ubyte bgcolor, ubyte bordercolor) {
+        @($D021) = bgcolor & 15  ; 背景色
+        @($D020) = bordercolor & 15  ; ボーダー色
     }
     
     ; 表示モード切り替え

--- a/prog8/src/jtxt.p8
+++ b/prog8/src/jtxt.p8
@@ -37,22 +37,22 @@ jtxt {
     uword color_pos = $D800             ; 現在のカラーRAM位置（screen_posと対応）
     ubyte current_color = 1             ; 現在の文字色（デフォルト：白）
     const uword SCREEN_END = SCREEN_RAM + 999  ; 画面最終位置（999 = 24*40+39）
-    
-    ; Shift-JISステート管理
-    ubyte sjis_state = 0                ; 0=通常, 1=Shift-JIS 2バイト目待ち
-    ubyte sjis_first_byte = 0           ; Shift-JIS 1バイト目の保存
+
+    uword @zp define_addr               ; フォント定義アドレス
+
+    ; Shift-JISステート管理（sjis_first_byte!=0 で2バイト目待ちを表す）
+    ubyte sjis_first_byte = 0           ; 0=通常, 非0=Shift-JIS 1バイト目保存
     
     ; ビットマップモード関連変数
     ubyte display_mode = TEXT_MODE      ; 現在の表示モード
-    ubyte bitmap_x = 0                  ; ビットマップ X座標（文字単位 0-39）
-    ubyte bitmap_y = 0                  ; ビットマップ Y座標（文字単位 0-24）
-    ubyte bitmap_fg_color = 1           ; ビットマップ前景色
-    ubyte bitmap_bg_color = 0           ; ビットマップ背景色
+    ubyte cursor_x = 0                  ; ビットマップ X座標（文字単位 0-39）
+    ubyte cursor_y = 0                  ; ビットマップ Y座標（文字単位 0-24）
+    ubyte bitmap_color = (1 << 4) | 0   ; ビットマップ色
     
     ; ビットマップ行範囲制御変数
     ubyte bitmap_top_row = 0            ; 描画開始行（デフォルト: 0）
     ubyte bitmap_bottom_row = 24        ; 描画終了行（デフォルト: 24）
-    bool bitmap_window_enabled = false ; 行範囲制御有効フラグ
+    bool bitmap_window_enabled = false  ; ビットマップ行範囲制御有効フラグ
     
     ; ハードウェア初期化（モード設定のみ、文字範囲はデフォルトを使用）
     sub init(ubyte mode) {
@@ -95,53 +95,38 @@ jtxt {
         color_pos = $D800                  ; カラーRAM左上から開始
     }
     
-    ; ライブラリ使用文字のクリア（最適化：範囲限定）
+    ; 画面クリア（全領域を無条件にスペースで埋める）
     sub cls() {
-        ; 画面上のライブラリ文字をクリア（最適化：1回のループ）
-        uword screen_ptr = SCREEN_RAM
-        uword screen_end = SCREEN_RAM + 1000    ; 25行×40文字
-        ubyte char_end = chr_start + chr_count
+        sys.memset(SCREEN_RAM, 1000, 32)  ; 25行×40文字をスペースでクリア
         
-        while screen_ptr < screen_end {
-            ubyte ch = @(screen_ptr)
-            if ch >= chr_start and ch < char_end {
-                @(screen_ptr) = 32  ; スペース文字（C64スクリーンコード）
-            }
-            screen_ptr++
-        }
-        
-        ; インデックス初期化（最適化：代入のみ）
+        ; インデックス初期化
         current_index = chr_start
-        locate(0, 0)  ; 画面左上に位置設定（アドレス事前計算）
+        locate(0, 0)
         
         ; Shift-JISステートもクリア
-        sjis_state = 0
         sjis_first_byte = 0
     }
     
-    ; カーソル位置設定（最適化：アドレス事前計算）
+    ; カーソル位置設定
     sub locate(ubyte x, ubyte y) {
-        uword offset = (y as uword) * CHAR_WIDTH + x as uword
-        screen_pos = SCREEN_RAM + offset
-        color_pos = $D800 + offset
+        screen_pos = SCREEN_RAM + (y as uword) * CHAR_WIDTH + x as uword
+        color_pos = screen_pos + ($D800 - SCREEN_RAM)
     }
     
     ; 1文字出力（txt.putc互換、Shift-JISステートフル処理）
     sub putc(ubyte char_code) {
-        ; Shift-JIS 2バイト目待ち状態の処理
-        if sjis_state == 1 {
+        ; Shift-JIS 2バイト目待ち状態の処理（sjis_first_byte!=0）
+        if sjis_first_byte != 0 {
             ; 2バイト目として有効な範囲チェック
             if (char_code >= $40 and char_code <= $7E) or (char_code >= $80 and char_code <= $FC) {
                 ; Shift-JIS文字として処理
                 uword sjis_code = (sjis_first_byte as uword << 8) | char_code as uword
                 putc_internal(sjis_code)
-                sjis_state = 0
                 sjis_first_byte = 0
                 return
             } else {
                 ; 無効な2バイト目の場合、1バイト目を単独で出力してリセット
                 putc_internal(sjis_first_byte as uword)
-                sjis_state = 0
                 sjis_first_byte = 0
                 ; そして現在の文字を処理続行
             }
@@ -150,7 +135,6 @@ jtxt {
         ; Shift-JIS 1バイト目判定
         if (char_code >= $81 and char_code <= $9F) or (char_code >= $E0 and char_code <= $FC) {
             ; Shift-JIS 1バイト目として保存
-            sjis_state = 1
             sjis_first_byte = char_code
             return
         }
@@ -190,40 +174,63 @@ jtxt {
         }
     }
     
-    ; 文字列出力（putcを使用してステートフル処理）
+    ; 文字列出力
     sub puts(uword addr) {
-        uword ptr = addr
-        
-        while @(ptr) != 0 {
-            putc(@(ptr))
-            ptr++
-        }
+        %asm {{
+-
+            ldy  #0
+            lda  (p8v_addr),y
+            cmp  #0
+            beq  _puts_done
+            jsr  p8b_jtxt.p8s_putc
+            inc  p8v_addr
+            bne  +
+            inc  p8v_addr+1
++
+            jmp  -
+_puts_done
+        }}
     }
     
     ; 改行処理
+    ; ※単純にx=0、y++してlocateした方がいいかも
     sub newline() {
         ; 現在の画面位置から画面先頭アドレスを引いて相対位置を取得
-        uword relative_pos = screen_pos - SCREEN_RAM
+        screen_pos -= SCREEN_RAM
         ; 40で割って現在行を求める
-        uword current_row = relative_pos / 40
-        if current_row < 24 {
-            current_row++
+        screen_pos /= 40
+        if screen_pos < 24 {
+            screen_pos++
         }
-        current_row = current_row * 40
+        screen_pos *= 40
         ; 次の行の先頭アドレスを計算
-        screen_pos = SCREEN_RAM + current_row
-        color_pos = $D800 + current_row
+        screen_pos += SCREEN_RAM
+        color_pos = screen_pos + ($D800 - SCREEN_RAM)
     }
 
     ; 文字色設定（最適化：単純代入）
-    sub set_color(ubyte color) {
-        current_color = color & 15  ; 下位4ビットのみ有効
+    asmsub set_color(ubyte color @ A) {
+        ; current_color = color & 15  ; 下位4ビットのみ有効
+        %asm {{
+            and  #15
+            sta  p8b_jtxt.p8v_current_color
+            rts
+        }}
     }
     
-    ; 背景色/ボーダー色設定（2引数に統合）
-    sub set_bgcolor(ubyte bgcolor, ubyte bordercolor) {
-        @($D021) = bgcolor & 15  ; 背景色
-        @($D020) = bordercolor & 15  ; ボーダー色
+    ; 背景色/ボーダー色設定
+    asmsub set_bgcolor(ubyte bgcolor @ A, ubyte bordercolor @ Y) {
+        %asm {{
+            ; 背景色
+            and  #15
+            sta  $d021
+
+            ; ボーダー色
+            tya
+            and  #15
+            sta  $d020
+            rts
+        }}
     }
     
     ; 表示モード切り替え
@@ -245,69 +252,72 @@ jtxt {
             @($D011) = @($D011) & %11011111  ; BMM=0 (ビットマップモード無効)
             
             ; VICバンク0に戻す（$0000-$3FFF）
-            @($DD00) = (@($DD00) & %11111100) | %00000011  ; VICバンク0選択
-            
-            ubyte vic_reg = @($D018)
-            vic_reg &= %11110000
-            vic_reg |= %00001100              ; キャラクタRAM=$3000
-            @($D018) = vic_reg
+            @($DD00) = (@($DD00) & %11111100) | %00000011   ; VICバンク1選択
+
+            @($D018) = (@($D018) & %11110000) | %00001100   ; キャラクタRAM=$3000
         }
     }
     
     ; ビットマップ画面クリア
     sub bcls() {
-        if bitmap_window_enabled {
-            ; 行範囲制御が有効な場合、指定範囲のみクリア
-            ubyte row
-            for row in bitmap_top_row to bitmap_bottom_row {
-                ; 各行のビットマップデータをクリア（1行は320バイト）
-                uword row_addr = BITMAP_BASE + (row as uword) * 320
-                sys.memset(row_addr, 320, 0)
-                
-                ; 各行のカラー情報をクリア
-                uword color_row_addr = BITMAP_SCREEN_RAM + (row as uword) * 40
-                sys.memset(color_row_addr, 40, (bitmap_fg_color << 4) | bitmap_bg_color)
-            }
-            
-            ; カーソル位置を範囲の開始位置に設定
-            bitmap_x = 0
-            bitmap_y = bitmap_top_row
-        } else {
-            ; 行範囲制御が無効な場合、全画面クリア
-            sys.memset(BITMAP_BASE, 8000, 0)
-            sys.memset(BITMAP_SCREEN_RAM, 1000, (bitmap_fg_color << 4) | bitmap_bg_color)
-            
-            ; ビットマップ座標初期化
-            bitmap_x = 0
-            bitmap_y = 0
+        ; 行範囲制御が有効な場合、指定範囲のみクリア
+        ubyte row
+        cx16.r2 = BITMAP_BASE + (bitmap_top_row as uword) * 320
+        cx16.r3 = BITMAP_SCREEN_RAM + (bitmap_top_row as uword) * 40
+        for row in bitmap_top_row to bitmap_bottom_row {
+            ; 各行のビットマップデータをクリア（1行は320バイト）
+            sys.memset(cx16.r2, 320, 0)
+            cx16.r2 += 320
+
+            ; 各行のカラー情報をクリア
+            sys.memset(cx16.r3, 40, bitmap_color)
+            cx16.r3 += 40
         }
         
+        ; カーソル位置を範囲の開始位置に設定
+        cursor_x = 0
+        cursor_y = bitmap_top_row
+        
         ; Shift-JISステートもクリア
-        sjis_state = 0
         sjis_first_byte = 0
     }
     
     ; ビットマップ座標設定
-    sub blocate(ubyte x, ubyte y) {
-        bitmap_x = x
-        bitmap_y = y
+    asmsub blocate(ubyte x @ A, ubyte y @ Y) {
+        %asm {{
+            sta  p8b_jtxt.p8v_cursor_x
+            sty  p8b_jtxt.p8v_cursor_y
+            rts
+        }}
     }
     
     ; ビットマップ色設定
-    sub bcolor(ubyte fg, ubyte bg) {
-        bitmap_fg_color = fg & 15
-        bitmap_bg_color = bg & 15
+    asmsub bcolor(ubyte fg @ A, ubyte bg @ Y) clobbers(A) {
+        %asm {{
+            sty  cx16.r2
+            and  #15
+            asl  a
+            asl  a
+            asl  a
+            asl  a
+            ora  cx16.r2
+            sta  p8b_jtxt.p8v_bitmap_color
+            rts
+        }}
     }
     
     ; ビットマップ行範囲設定
-    sub bwindow(ubyte top_row, ubyte bottom_row) {
-        if top_row <= bottom_row and bottom_row <= 24 {
-            bitmap_top_row = top_row
-            bitmap_bottom_row = bottom_row
-            bitmap_window_enabled = true
-        }
+    asmsub bwindow(ubyte top_row @ A, ubyte bottom_row @ Y) {
+        ; ignore top_row <= bottom_row and bottom_row <= 24
+        ; if top_row <= bottom_row and bottom_row <= 24 {
+        %asm {{
+            sta  p8b_jtxt.p8v_bitmap_top_row
+            sty  p8b_jtxt.p8v_bitmap_bottom_row
+            rts
+        }}
+        ; }
     }
-    
+
     ; ビットマップ行範囲制御無効化
     sub bwindow_disable() {
         bitmap_window_enabled = false
@@ -320,47 +330,37 @@ jtxt {
     
     ; ビットマップモード改行処理
     sub bnewline() {
-        bitmap_x = 0
+        cursor_x = 0
         
-        if bitmap_window_enabled {
-            ; 行範囲制御有効時
-            if bitmap_y >= bitmap_bottom_row {
-                ; 最下行の場合、スクロール
+        ; 行範囲制御有効時
+        if cursor_y >= bitmap_bottom_row {
+            ; 最下行の場合、スクロール(bitmap_window_enabled=trueの場合)
+            if bitmap_window_enabled {
                 bscroll_up()
-                bitmap_y = bitmap_bottom_row
-            } else {
-                bitmap_y++
             }
+            cursor_y = bitmap_bottom_row
         } else {
-            ; 行範囲制御無効時
-            if bitmap_y >= 24 {
-                ; 24行目で止める（スクロールしない）
-                bitmap_y = 24
-            } else {
-                bitmap_y++
-            }
+            cursor_y++
         }
     }
     
     ; ビットマップモードバックスペース処理
     sub bbackspace() {
         ; Shift-JIS 2バイト目待ち状態の場合はキャンセルのみ
-        if sjis_state == 1 {
-            sjis_state = 0
+        if sjis_first_byte != 0 {
             sjis_first_byte = 0
             return
         }
         
         ; カーソル位置を1つ戻す
-        if bitmap_x > 0 {
+        if cursor_x != 0 {
             ; 同じ行内での後退
-            bitmap_x--
+            cursor_x--
         } else {
             ; 行頭の場合、前の行の行末に移動
-            ubyte min_row = if bitmap_window_enabled bitmap_top_row else 0
-            if bitmap_y > min_row {
-                bitmap_y--
-                bitmap_x = 39  ; 前の行の最後の位置
+            if cursor_y > bitmap_top_row {
+                cursor_y--
+                cursor_x = 39  ; 前の行の最後の位置
             } else {
                 ; 範囲の上端または画面の左上角の場合は何もしない
                 return
@@ -368,63 +368,38 @@ jtxt {
         }
         
         ; 行範囲制御が有効で、範囲外の場合は描画しない
-        if bitmap_window_enabled {
-            if bitmap_y < bitmap_top_row or bitmap_y > bitmap_bottom_row {
-                return
-            }
+        if cursor_y < bitmap_top_row or cursor_y > bitmap_bottom_row {
+            return
         }
         
         ; 現在位置に空白文字を描画（文字を消去）
-        draw_font_to_bitmap(32, bitmap_x, bitmap_y)  ; 32 = スペース文字
+        draw_font_to_bitmap(32)  ; 32 = スペース文字
     }
     
-    ; ビットマップ画面を上に1行スクロール（1行ずつ同期版）
+    ; ビットマップ画面を上に1行スクロール
     sub bscroll_up() {
-        if bitmap_window_enabled {
-            ; 行範囲制御が有効な場合、指定範囲内のみスクロール
-            ubyte row_w
-            for row_w in bitmap_top_row to bitmap_bottom_row - 1 {
-                ; ビットマップデータをコピー（1文字行分）
-                uword src_addr_w = BITMAP_BASE + ((row_w + 1) as uword) * 320
-                uword dest_addr_w = BITMAP_BASE + (row_w as uword) * 320
-                sys.memcopy(src_addr_w, dest_addr_w, 320)
-                
-                ; 同じ行のカラー情報もすぐにコピー
-                uword src_color_w = BITMAP_SCREEN_RAM + ((row_w + 1) as uword) * 40
-                uword dest_color_w = BITMAP_SCREEN_RAM + (row_w as uword) * 40
-                sys.memcopy(src_color_w, dest_color_w, 40)
-            }
+        ; 行範囲制御が有効な場合、指定範囲内のみスクロール
+        cx16.r3 = BITMAP_BASE + (bitmap_top_row as uword) * 320         ; dst
+        cx16.r2 = cx16.r3 + 320                                         ; src
+        cx16.r5 = BITMAP_SCREEN_RAM + (bitmap_top_row as uword) * 40    ; dst
+        cx16.r4 = cx16.r5 + 40                                          ; src
+        repeat bitmap_bottom_row - bitmap_top_row {
+            ; ビットマップデータをコピー（1行分）
+            sys.memcopy(cx16.r2, cx16.r3, 320)
+            cx16.r2 += 320
+            cx16.r3 += 320
             
-            ; 範囲内の最下行をクリア
-            uword last_row_w = BITMAP_BASE + (bitmap_bottom_row as uword) * 320
-            sys.memset(last_row_w, 320, 0)
-            
-            ; 範囲内の最下行のカラー情報をクリア
-            uword last_color_w = BITMAP_SCREEN_RAM + (bitmap_bottom_row as uword) * 40
-            sys.memset(last_color_w, 40, (bitmap_fg_color << 4) | bitmap_bg_color)
-        } else {
-            ; 行範囲制御が無効な場合、全画面スクロール
-            ubyte row
-            for row in 0 to 23 {
-                ; ビットマップデータをコピー（1文字行分）
-                uword src_addr = BITMAP_BASE + ((row + 1) as uword) * 320
-                uword dest_addr = BITMAP_BASE + (row as uword) * 320
-                sys.memcopy(src_addr, dest_addr, 320)
-                
-                ; 同じ行のカラー情報もすぐにコピー
-                uword src_color_addr = BITMAP_SCREEN_RAM + ((row + 1) as uword) * 40
-                uword dest_color_addr = BITMAP_SCREEN_RAM + (row as uword) * 40
-                sys.memcopy(src_color_addr, dest_color_addr, 40)
-            }
-            
-            ; 最下行（24行目）をクリア
-            uword last_row_addr = BITMAP_BASE + 7680  ; 24 * 320
-            sys.memset(last_row_addr, 320, 0)
-            
-            ; 最下行のカラー情報をクリア
-            uword last_color_addr = SCREEN_RAM + 960  ; 24 * 40
-            sys.memset(last_color_addr, 40, (bitmap_fg_color << 4) | bitmap_bg_color)
+            ; 同じ行のカラー情報もすぐにコピー
+            sys.memcopy(cx16.r4, cx16.r5, 40)
+            cx16.r4 += 40
+            cx16.r5 += 40
         }
+        
+        ; 範囲内の最下行をクリア
+        sys.memset(cx16.r3, 320, 0)         ; r3 = 最下行になっている(はず)
+        
+        ; 範囲内の最下行のカラー情報をクリア
+        sys.memset(cx16.r5, 40, bitmap_color)     ; r5 = 最下行になっている(はず)
     }
     
     
@@ -448,46 +423,108 @@ jtxt {
     ; 以下は内部関数（最適化：呼び出し回数最小化）
     
     ; キャラクタセットをROMからRAMにコピー
-    sub copy_charset_to_ram() {
-        uword i
-        for i in 0 to 2047 {
-            ubyte char_data = @(CHARSET_ROM + i)
-            @(CHARSET_RAM + i) = char_data
-        }
+    asmsub copy_charset_to_ram() {
+        %asm {{
+            ; Set ROM Pointer
+            lda #<p8c_CHARSET_ROM
+            sta cx16.r2
+            lda #>p8c_CHARSET_ROM
+            ; lda #$d8    ; char set 2
+            sta cx16.r2 + 1
+
+            ; Set RAM Pointer
+            lda #<p8c_CHARSET_RAM
+            sta cx16.r3
+            lda #>p8c_CHARSET_RAM
+            sta cx16.r3 + 1
+
+            ; Copy ROM to RAM
+            ; $d000 -> $3000
+            ldx #$08            ; 8 pages of 256 bytes = 2KB
+            ldy #$00
+-
+            lda (cx16.r2),y     ; read byte from vector stored in cx16.r2/cx16.r2+1
+            sta (cx16.r3),y     ; write to the RAM
+            iny                 ; do this 255 times...
+            bne -               ;  ..for low byte $00 to $FF
+
+            inc cx16.r2 + 1     ; Increase high bytes
+            inc cx16.r3 + 1
+            dex                 ; decrease X by one
+            bne -
+            rts
+        }}
     }
     
     ; JIS X 0201半角文字データを指定アドレスに書き込み（低レベル関数）
-    sub define_jisx0201(uword dest_addr, ubyte jisx0201_code) {
-        uword font_offset = (jisx0201_code as uword) * 8
-        @(BANK_REG) = 1
-        
-        ubyte row
-        for row in 0 to 7 {
-            @(dest_addr + row as uword) = @(ROM_BASE + font_offset + row as uword)
-        }
-        
-        @(BANK_REG) = 0
+    asmsub define_jisx0201(ubyte jisx0201_code @ A) {
+        %asm {{
+            ldy  #0
+            sty  P8ZP_SCRATCH_B1
+            asl  a
+            rol  P8ZP_SCRATCH_B1
+            asl  a
+            rol  P8ZP_SCRATCH_B1
+            asl  a
+            rol  P8ZP_SCRATCH_B1
+            ldy  P8ZP_SCRATCH_B1
+            clc
+            adc  #<p8c_ROM_BASE
+            tax
+            tya
+            adc  #>p8c_ROM_BASE
+            tay
+            txa
+            sta  cx16.r2
+            sty  cx16.r2 + 1
+
+            lda  #1
+            sta  p8c_BANK_REG
+
+            lda  #8
+            sta  define_jisx0201_tempv
+-
+            ldy  #0
+            lda  (cx16.r2),y
+            sta  (p8b_jtxt.p8v_define_addr),y
+            inc  p8b_jtxt.p8v_define_addr
+            bne  +
+            inc  p8b_jtxt.p8v_define_addr+1
++
+            inc  cx16.r2
+            bne  +
+            inc  cx16.r2 + 1
++
+            dec  define_jisx0201_tempv
+            bne  -
+
+            lda  #0
+            sta  p8c_BANK_REG
+            rts
+
+            .section BSS_NOCLEAR
+define_jisx0201_tempv    .byte  ?
+            .send BSS_NOCLEAR
+; !notreached!
+        }}
     }
     
     ; Shift-JISコードから漢字ROMオフセットを計算
     sub sjis_to_offset(uword sjis_code) -> uword {
-        uword @zp ch = msb(sjis_code)
-        uword @zp ch2 = lsb(sjis_code)
+        ubyte @zp ch = msb(sjis_code)
+        ubyte @zp ch2 = lsb(sjis_code)
         
         ; ShiftJIS -> Ku/Ten変換
+        uword row = (ch as uword) << 1
         if ch <= $9f {
-            if ch2 < $9f {
-                ch = (ch as uword << 1) - $102
-            } else {
-                ch = (ch as uword << 1) - $101
-            }
+            row -= $0102
         } else {
-            if ch2 < $9f {
-                ch = (ch as uword << 1) - $182
-            } else {
-                ch = (ch as uword << 1) - $181
-            }
+            row -= $0182
         }
+        if ch2 >= $9f {
+            row++
+        }
+        ch = lsb(row)
 
         if ch2 < $7f {
             ch2 -= $40
@@ -497,19 +534,18 @@ jtxt {
             ch2 -= $9f
         }
         
-        uword code = ch * 94 + ch2
-        uword offset = code * 8 + JISX0208_OFFSET
-        return offset
+        return ((ch as uword) * 94 + ch2 as uword)* 8 + JISX0208_OFFSET
     }
     
     ; 指定アドレスにフォントデータを書き込み（汎用関数）
     sub define_font(uword dest_addr, uword code) {
-        if code <= 255 {
+        define_addr = dest_addr
+        if msb(code) == 0 {
             ; 1バイト文字（ASCII、半角カナ）
-            define_jisx0201(dest_addr, lsb(code))
+            define_jisx0201(lsb(code))
         } else {
             ; 2バイト文字（漢字）
-            define_kanji(dest_addr, code)
+            define_kanji(code)
         }
     }
     
@@ -519,7 +555,7 @@ jtxt {
     }
     
     ; Shift-JIS漢字データを指定アドレスに書き込み（低レベル関数、MagicDesk用8KBバンク）
-    sub define_kanji(uword dest_addr, uword sjis_code) {
+    sub define_kanji(uword sjis_code) {
         uword kanji_offset = sjis_to_offset(sjis_code)
         ubyte bank = (kanji_offset / 8192) as ubyte + 1
         uword in_bank_offset = kanji_offset % 8192
@@ -530,7 +566,7 @@ jtxt {
         
         ubyte row
         for row in 0 to 7 {
-            @(dest_addr + row as uword) = @(rom_addr + row as uword)
+            @(define_addr + row as uword) = @(rom_addr + row as uword)
         }
         
         @(BANK_REG) = 0
@@ -538,20 +574,18 @@ jtxt {
     
     ; ビットマップモードで1文字描画（txt.putc互換、Shift-JISステートフル処理）
     sub bputc(ubyte char_code) {
-        ; Shift-JIS 2バイト目待ち状態の処理
-        if sjis_state == 1 {
+        ; Shift-JIS 2バイト目待ち状態の処理（sjis_first_byte!=0）
+        if sjis_first_byte != 0 {
             ; 2バイト目として有効な範囲チェック
             if (char_code >= $40 and char_code <= $7E) or (char_code >= $80 and char_code <= $FC) {
                 ; Shift-JIS文字として処理
                 uword sjis_code = (sjis_first_byte as uword << 8) | char_code as uword
                 bputc_internal(sjis_code)
-                sjis_state = 0
                 sjis_first_byte = 0
                 return
             } else {
                 ; 無効な2バイト目の場合、1バイト目を単独で出力してリセット
                 bputc_internal(sjis_first_byte as uword)
-                sjis_state = 0
                 sjis_first_byte = 0
                 ; そして現在の文字を処理続行
             }
@@ -560,7 +594,6 @@ jtxt {
         ; Shift-JIS 1バイト目判定
         if (char_code >= $81 and char_code <= $9F) or (char_code >= $E0 and char_code <= $FC) {
             ; Shift-JIS 1バイト目として保存
-            sjis_state = 1
             sjis_first_byte = char_code
             return
         }
@@ -588,23 +621,16 @@ jtxt {
     ; 内部用ビットマップ文字出力（実際の描画処理）
     sub bputc_internal(uword char_code) {
         ; 行範囲制御が有効で、範囲外の場合は何もしない
-        if bitmap_window_enabled {
-            if bitmap_y < bitmap_top_row or bitmap_y > bitmap_bottom_row {
-                return
-            }
-        }
-        
-        ; 範囲制御無効時も24行目を超えたら何もしない
-        if not bitmap_window_enabled and bitmap_y > 24 {
+        if bitmap_window_enabled and (cursor_y < bitmap_top_row or cursor_y > bitmap_bottom_row) {
             return
         }
         
         ; ビットマップアドレスを計算して直接書き込み
-        draw_font_to_bitmap(char_code, bitmap_x, bitmap_y)
+        draw_font_to_bitmap(char_code)
         
         ; 次の文字位置へ
-        bitmap_x++
-        if bitmap_x >= 40 {
+        cursor_x++
+        if cursor_x >= 40 {
             ; 自動改行処理
             bnewline()
         }
@@ -621,29 +647,14 @@ jtxt {
     }
     
     ; フォントデータを直接ビットマップメモリに描画
-    sub draw_font_to_bitmap(uword char_code, ubyte x, ubyte y) {
-        ; ビットマップ上の位置を計算
-        ; C64のビットマップレイアウト：
-        ; - 画面は8行ごとのブロックに分かれる（0-7行、8-15行、16-23行、24行）
-        ; - 各ブロック内で、文字は左から右、上から下の順に配置
-        ; - 各文字は8バイト連続で格納
-        
-        ubyte char_row = y / 8            ; 文字のブロック行（0-3）
-        ubyte char_line = y & 7           ; ブロック内の行（0-7）
-        
-        ; ビットマップアドレス計算
-        ; ブロック開始 + ブロック内の行オフセット + 文字位置
-        uword bitmap_addr = BITMAP_BASE +
-                           (char_row as uword) * 320 * 8 +    ; ブロック行オフセット（各2560バイト）
-                           (char_line as uword) * 320 +       ; ブロック内行オフセット
-                           (x as uword) * 8                   ; X位置（各文字8バイト）
-        
+    sub draw_font_to_bitmap(uword char_code) {
+        ; TODO 毎回cursor_x, cursor_yからアドレスを計算するのは無駄なのでそのうち最適化を検討したい
+
         ; カラー情報設定（ビットマップモード用画面RAMの該当位置）
-        uword color_addr = BITMAP_SCREEN_RAM + (y as uword) * 40 + x as uword
-        @(color_addr) = (bitmap_fg_color << 4) | bitmap_bg_color
+        @(BITMAP_SCREEN_RAM + (cursor_y as uword) * 40 + cursor_x as uword) = bitmap_color
         
         ; フォントデータを直接ビットマップに書き込み
-        define_font(bitmap_addr, char_code)
+        define_font(BITMAP_BASE + ((cursor_y / 8) as uword) * 320 * 8 + ((cursor_y & 7) as uword) * 320 + (cursor_x as uword) * 8, char_code)
     }
     
     ; 文字列リソースを内部バッファに読み込み（共通処理）

--- a/prog8/src/modem_test.p8
+++ b/prog8/src/modem_test.p8
@@ -24,8 +24,8 @@ main {
         ; IME初期化
         ime.init()
         
-        ; ライブラリ初期化（文字範囲64-254、190文字使用、ビットマップモード）
-        jtxt.init(64, 190, jtxt.BITMAP_MODE)
+        ; ライブラリ初期化（ビットマップモード）
+        jtxt.init(jtxt.BITMAP_MODE)
         
         ; 画面設定
         jtxt.bcolor(5, 0)  ; 緑文字、黒背景（ターミナル風）

--- a/prog8/src/modem_test.p8
+++ b/prog8/src/modem_test.p8
@@ -152,8 +152,8 @@ main {
                             }
                         }
                         if echo_mode {
-                            cursor_x = jtxt.bitmap_x
-                            cursor_y = jtxt.bitmap_y
+                            cursor_x = jtxt.cursor_x
+                            cursor_y = jtxt.cursor_y
                         }
                     }
                     ; 結果バッファをクリア
@@ -254,7 +254,7 @@ main {
                                     if echo_mode {
                                         jtxt.bputc(key)
                                         cursor_x++
-                                        cursor_y = jtxt.bitmap_y
+                                        cursor_y = jtxt.cursor_y
                                     }
                                     ; モデムに送信（接続時）
                                     if modem_connected {
@@ -289,7 +289,7 @@ main {
                                 jtxt.bputc(data)  ; CRを表示（これが改行処理）
                                 jtxt.bcolor(5, 0)
                                 cursor_x = 0      ; カーソル位置リセット
-                                cursor_y = jtxt.bitmap_y  ; 同期
+                                cursor_y = jtxt.cursor_y  ; 同期
                             }
                             ; 40の倍数位置なら何もしない（自動改行済み）
                         } else if data == 8 {
@@ -310,7 +310,7 @@ main {
                             jtxt.bputc(data)
                             jtxt.bcolor(5, 0)  ; 緑に戻す
                             cursor_x++  ; 単純に加算
-                            cursor_y = jtxt.bitmap_y  ; 同期
+                            cursor_y = jtxt.cursor_y  ; 同期
                         }
                     }
                 }
@@ -428,8 +428,8 @@ main {
         ; jtxtの行範囲制御に任せて改行実行
         jtxt.bputc(13)
         cursor_x = 0  ; 改行したら0にリセット
-        ; cursor_yをjtxt.bitmap_yと同期
-        cursor_y = jtxt.bitmap_y
+        ; cursor_yをjtxt.cursor_yと同期
+        cursor_y = jtxt.cursor_y
     }
     
     sub show_message(uword message, ubyte color) {


### PR DESCRIPTION
## Summary

- Add comprehensive C language support to c64jp using llvm-mos toolchain
- Implement QE: Vi-like modal text editor with full Japanese language support
- Port jtxt and ime libraries from Prog8 to C for broader compatibility
- Optimize libraries for 8-bit C64 memory constraints

## Changes

### C Language Libraries
- **jtxt library**: Japanese text display with bitmap/text mode support
  - Shift-JIS encoding with proper 2-byte character handling
  - Font loading from MagicDesk cartridge ROM banks
  - PCG (Programmable Character Generator) for efficient rendering
- **ime library**: Kana-kanji conversion (IME) from Prog8 port
  - Roman-ji → Hiragana/Katakana → Kanji conversion
  - Dictionary access from MagicDesk cartridge banks
  - Learning function for frequently used candidates

### QE Text Editor (`c/src/qe/`)
- Vi-like modal editor: Normal/Insert/Replace modes with intuitive operation
- Full Shift-JIS support: Proper 2-byte character boundary detection
- Japanese input: IME integration (Commodore+Space to activate)
- File I/O: Save/load using C64 KERNAL routines
- Efficient cursor display: Color inversion without screen flicker
- Gap buffer implementation: Fast text insertion/deletion
- Memory layout: 11KB editor buffer ($A000-$CBFF), 39.37% RAM usage
- Comprehensive documentation: README with modal editor concept explanation

### Build System
- CMake for C libraries (c/CMakeLists.txt)
- Makefile for QE editor with IME toggle support
- Test programs: hello.c, ime_test.c, jtxt_test.c

### Code Optimizations
- Remove runtime `jtxt_mode` checks (always bitmap mode)
- Replace custom `kernal_getin.s` with standard `cbm_k_getin()`
- LTO and dead code elimination for minimal binary size

## Technical Details

- **Compiler**: llvm-mos (mos-c64-clang)
- **Memory**: Editor buffer 11KB, bitmap screen $5C00-$7FFF
- **Encoding**: Shift-JIS with CR line endings
- **License**: BSD 2-Clause (based on David Given's qe editor)
- **Dependencies**: MagicDesk cartridge with Japanese fonts and dictionary

## Test Plan

- [x] Build QE editor with IME enabled/disabled
- [x] Test Japanese text input and display
- [x] Verify file save/load operations
- [x] Test cursor movement with Shift-JIS characters
- [x] Verify all Vi-like operations (insert, delete, replace, etc.)
- [x] Test IME activation and conversion
- [x] Confirm proper exit to BASIC

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce llvm-mos C toolchain with new C libraries (jtxt, ime) and QE editor, and integrate C builds/artifacts into CI, Makefile, D64, and release packaging while adjusting Prog8 APIs accordingly.
> 
> - **C/llvm-mos support**:
>   - Add C libraries `jtxt`, `ime` (Shift-JIS, MagicDesk ROM access, IME/dictionary) and tests (`hello_c`, `test_jtxt`, `ime_test_c`).
>   - Add QE Vi-like editor (`c/src/qe`) with gap buffer, IME integration, KERNAL file I/O, and docs; CMake-based build (`c/CMakeLists.txt`).
> - **Build/CI**:
>   - Workflows install llvm-mos and update build summary to include C artifacts; release bundles C docs.
> - **Makefile**:
>   - Add C/QE targets (build/run/test/clean), include C programs in `build-all`/`d64`, and enhance clean-all; use Prog8 compiler with `-asmlist`.
> - **Release packaging**:
>   - Release notes list Prog8 vs C programs; package QE README; build summary shows Prog8 and C output sizes.
> - **Repo maintenance**:
>   - Update `.gitignore` for C/llvm-mos outputs.
> - **Prog8 sources**:
>   - Update `jtxt` API usage (new `init`, combined `set_bgcolor`, bitmap/window/cursor APIs) across examples and IME; minor behavior refinements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3d17b04f83538f5aea3bcf571890bf81beadf4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->